### PR TITLE
resolve ReSpec dfn, link and heading issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,45 +73,33 @@ rights and obligations pertaining to any particular situation.</p>
 <p><a href="/Consortium/pwe/#Education">Education and training materials</a>
 are available from the <a href="/Consortium/pwe/">Positive Work Environment
 public homepage</a>.</p>
+</section>
 
-<div style="padding: 1em; 
-   margin: 0em; 
-   margin-bottom: 2em; 
+<section>
+<h2>Statement of Intent</h2>
 
-   border:2px solid blue; 
-
-   box-shadow: 10px 10px 5px #888;
-   -moz-box-shadow: 10px 10px 5px #888;
-   -webkit-box-shadow: 10px 10px 5px #888;
-
-    -moz-border-radius: 5px;
-    -webkit-border-radius: 5px;
-    -khtml-border-radius: 5px;
-    border-radius: 5px;
-">
-<h2><a name="Statement" id="Statement">Statement</a> of Intent</h2>
-
-<p style="margin-left:2em;">W3C is committed to maintain a
+<p>W3C is committed to maintain a
 <strong>positive</strong> work environment. This commitment calls for a
-workplace where <a href="#Participant">participants</a> at all levels
+workplace where <a>participants</a> at all levels
 <strong>behave</strong> according to the rules of the following code. A
 foundational concept of this code is that <strong>we all share
-responsibility</strong> for our <a href="#Work">work environment</a>.</p>
+responsibility</strong> for our <a>work environment</a>.</p>
+</section>
 
-<h2><a name="Code" id="Code">Code</a></h2>
+<section>
+<h2>Code</h2>
 <ol>
-  <li>Treat each other with <a href="#Respect">respect</a>, professionalism,
+  <li>Treat each other with <a>respect</a>, professionalism,
     fairness, and sensitivity to our many differences and strengths, including
     in situations of high pressure and urgency.</li>
-  <li>Never <a href="#Harassment">harass</a> or <a href="#Workplace">bully</a>
-    anyone verbally, physically or <a href="#Sexual">sexually</a>. </li>
-  <li>Never <a href="#Discrimination">discriminate</a> on the basis of personal
-    characteristics or group membership.</li>
-  <li>Communicate constructively and avoid <a href="#Demeaning">demeaning</a>
-    or <a href="#Insulting">insulting</a> behavior or language.</li>
-  <li>Seek, accept, and offer objective work criticism, and <a
-    href="#Acknowledgement">acknowledge</a> properly the contributions of
-    others. </li>
+  <li>Never <a>harass</a> or <a>bully</a> anyone verbally, physically or 
+    <a data-lt="sexual harassment">sexually</a>.</li>
+  <li>Never <a>discriminate</a> on the basis of personal characteristics or 
+    group membership.</li>
+  <li>Communicate constructively and avoid <a>demeaning</a> or <a>insulting</a>
+    behavior or language.</li>
+  <li>Seek, accept, and offer objective work criticism, and <a>acknowledge</a> 
+    properly the contributions of others. </li>
   <li>Be honest about your own qualifications, and about any circumstances that
     might lead to <a href="/Consortium/Process/policies.html#coi">conflicts of
     interest</a>.</li>
@@ -122,27 +110,23 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
     of data you access.</li>
   <li>With respect to cultural differences, be conservative in what you do and
     liberal in what you accept from others, but not to the point of accepting
-    disrespectful, unprofessional or unfair or <a href="#Unwelcome">unwelcome
-    behavior</a> or <a href="#Advance">advances</a>.</li>
+    disrespectful, unprofessional or unfair or <a>unwelcome behavior</a> or <a
+    data-lt="Unwelcome sexual advance">advances</a>.</li>
   <li>Promote the rules of this Code and take action (especially if you are in
-    a <a href="#Leadership">leadership position</a>) to bring the discussion
-    back to a more civil level whenever inappropriate behaviors are observed.
-  </li>
+    a <a>leadership position</a>) to bring the discussion back to a more civil
+    level whenever inappropriate behaviors are observed.</li>
 </ol>
-</div>
+</section>
 
-    </section>
-
-    <section id="glossary">
-
-<h2><a name="Glossary" id="Glossary">Glossary</a></h2>
+<section id="glossary">
+<h2>Glossary</h2>
 <dl>
-  <dt><a id="Demeaning" name="Demeaning">Demeaning behavior</a></dt>
+  <dt><dfn data-lt="demeaning|demean">Demeaning behavior</dfn></dt>
     <dd>is acting in a way that reduces another person's dignity, sense of
       self-worth or respect within the community. </dd>
 </dl>
 <dl>
-  <dt><a id="Discrimination" name="Discrimination">Discrimination</a></dt>
+  <dt><dfn data-lt="discriminate">Discrimination</dfn></dt>
     <dd>is the prejudicial treatment of an individual based on criteria such
       as: physical appearance, race, ethnic origin, genetic differences,
       national or social origin, name, religion, gender, sexual orientation,
@@ -151,26 +135,26 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
     activity.</dd>
 </dl>
 <dl>
-  <dt><a id="Insulting" name="Insulting">Insulting behavior</a></dt>
+  <dt><dfn data-lt="insulting|insult">Insulting behavior</dfn></dt>
     <dd>is treating another person with scorn or disrespect. </dd>
 </dl>
 <dl>
-  <dt><a id="Acknowledgement" name="Acknowledgement">Acknowledgement</a></dt>
-    <dd>is a record of the origin(s) and author(s) of a contribution. </dd>
+  <dt><dfn data-lt="acknowledge">Acknowledgement</dfn></dt>
+    <dd>is a record of the origin(s) and author(s) of a contribution.</dd>
 </dl>
 <dl>
-  <dt><a id="Harassment" name="Harassment">Harassment</a></dt>
+  <dt><dfn data-lt="harass">Harassment</dfn></dt>
     <dd>is any conduct, verbal or physical, that has the intent or effect of
       interfering with an individual, or that creates an intimidating, hostile,
       or offensive environment. </dd>
 </dl>
 <dl>
-  <dt><a id="Leadership" name="Leadership">Leadership position</a></dt>
+  <dt><dfn data-lt="leadership">Leadership position</dfn></dt>
     <dd>includes group Team contacts, group Chairs, W3C management, and
       Advisory Board members.</dd>
 </dl>
 <dl>
-  <dt><a id="Participant" name="Participant">Participant</a></dt>
+  <dt><dfn data-lt="participants">Participant</dfn></dt>
     <dd>includes the following persons:</dd>
     <dd><ul>
         <li>W3C Team (employees, contractors, fellows)</li>
@@ -182,19 +166,19 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
           etc)</li>
       </ul>
     </dd>
-  <dt><a id="Respect" name="Respect">Respect</a></dt>
+  <dt><dfn>Respect</dfn></dt>
     <dd>is the genuine consideration you have for someone (if only because of
       their status as participant in W3C, like yourself), and that you show by
       treating them in a polite and kind way.</dd>
 </dl>
 <dl>
-  <dt><a id="Sexual" name="Sexual">Sexual harassment</a></dt>
+  <dt><dfn data-lt="sexually harass">Sexual harassment</dfn></dt>
     <dd>includes visual displays of degrading sexual images, sexually
       suggestive conduct, offensive remarks of a sexual nature, requests for
       sexual favors, unwelcome physical contact, and sexual assault.</dd>
 </dl>
 <dl>
-  <dt><a id="Unwelcome" name="Unwelcome">Unwelcome behavior</a></dt>
+  <dt><dfn data-lt="unwelcome">Unwelcome behavior</dfn></dt>
     <dd>Hard to define? Some questions to ask yourself are: 
       <ul>
         <li>how would I feel if I were in the position of the recipient?</li>
@@ -213,7 +197,7 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
     </dd>
 </dl>
 <dl>
-  <dt><a id="Advance" name="Advance">Unwelcome sexual advance</a></dt>
+  <dt><dfn>Unwelcome sexual advance</dfn></dt>
     <dd>includes requests for sexual favors, and other verbal or physical
       conduct of a sexual nature, where: 
       <ul>
@@ -228,14 +212,14 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
     </dd>
 </dl>
 <dl>
-  <dt><a id="Workplace" name="Workplace">Workplace Bullying</a></dt>
+  <dt><dfn data-lt="bully">Workplace Bullying</dfn></dt>
     <dd>is a tendency of individuals or groups to use persistent aggressive or
       unreasonable behavior (e.g. verbal or written abuse, offensive conduct or
       any interference which undermines or impedes work) against a co-worker or
       any professional relations.</dd>
 </dl>
 <dl>
-  <dt><a id="Work" name="Work">Work Environment</a></dt>
+  <dt><dfn>Work Environment</dfn></dt>
     <dd>is the set of all available means of collaboration, including, but not
       limited to messages to mailing lists, private correspondence, Web pages,
       chat channels, phone and video teleconferences, and any kind of
@@ -247,9 +231,7 @@ responsibility</strong> for our <a href="#Work">work environment</a>.</p>
 
 <h2>Feedback &amp; Status</h2>
 
-<h3><a id="feedback" name="feedback">Feedback</a></h3>
-
-<p>...</p>
+<h3>Feedback</h3>
 
     </section>
 


### PR DESCRIPTION
Attempts to address remaining issues in #14.

(This removes the custom inline-styled box around the Code and just makes the Statement of intent and Code regular top-level sections in the table of contents. That seems to make it easier to read, review table of contents and link to, but I don't know if there's previous history for trying to make it separate in that way.)