### PR TITLE
Cite the operative CEPC

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,9 @@ acts as a vehicle for better identity of the organization.</p>
     <section id="sotd">
       <p>
         This is an unofficial proposal.
+	Refer to <a href="https://www.w3.org/Consortium/cepc/">Code of
+	Ethics and Professional Conduct</a> for the operational
+	version.
       </p>
     </section>
 


### PR DESCRIPTION
Add a citation to the operative CEPC.

(I'd have preferred a "Latest Operative Version" link in the metadata but respec doesn't seem to give me a way to add that.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/31.html" title="Last updated on Mar 1, 2019, 8:40 PM UTC (ef3ac2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/31/addf117...ef3ac2d.html" title="Last updated on Mar 1, 2019, 8:40 PM UTC (ef3ac2d)">Diff</a>