### PR TITLE
changes to "made a mistake" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,11 +219,11 @@ responsibility</strong> for our <a>work environment</a>.</p>
 	<p>Concerns about potential violations of the code of conduct should be reported to a W3C Ombudsperson as outlined in the complementary <a href="https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a> document.</p>
 	  </section>
 	  <section id="mistake">
-	<h2>If you make a mistake</h2>
+	<h2>If you've done something improper</h2>
 	<p>As we engage in diverse communities we may accidentally cause offense, whether through using unknowingly offensive terminology or through missing social cues.</p>
 <p>If you realise (or are told) that you have offended someone then take the appropriate steps:
 <ol>
-	<li>Accept that you have made a mistake</li>
+	<li>Acknowledge that you've done something improper</li>
 	<li>Briefly apologize. Don't try to explain yourself or minimise the issue.</li>
 <li>If possible, edit your message, restate your communication in a better way or withdraw your statement. Publicly revising your statement helps define the culture for others.</li></ul>
 


### PR DESCRIPTION
Based on recommendations from @lianqi adjusted language for a global audience (mistake is a very strong term in some cultures):
* s/If you make a mistake/If you've done something improper
* s/accept that you have made a mistake/acknowledge that you've done something improper


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/52.html" title="Last updated on Jun 5, 2019, 4:07 PM UTC (e49f21f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/52/25d7877...e49f21f.html" title="Last updated on Jun 5, 2019, 4:07 PM UTC (e49f21f)">Diff</a>