### PR TITLE
Whitespace and Linting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,367 +1,438 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Positive Work Environment at W3C: Code of Ethics and Professional Conduct</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
-    <script class='remove'>
-      // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
-      var respecConfig = {
-        specStatus: "base",
-        shortName: "pwe",
-        editors: [{
-          name: "Tzviya Siegman",
-          company: "Wiley",
-          companyURL: "https://www.wiley.com",
-          w3cid: 65542
-        },{
-          name: "An Qi Li",
-          company: "Ali Baba",
-          companyURL: "https://www.alibaba.com",
-          w3cid: 40190
-        }],
-        processVersion: 2018,
-        includePermalinks: false,
-        permalinkEdge:     true,
-        permalinkHide:     false,
-        diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-			  github:			 {
-				  repoURL: "https://github.com/w3c/PWETF/",
-				  branch: "master"
-			  },
-      };
-    </script>
-  </head>
-  <body>
-    <section id="abstract">
 
-<p>A <strong>Code of Ethics and Professional Conduct</strong> is useful to
-define accepted and acceptable behaviors and to promote high standards of
-professional practice. The goals of this code are to:</p>
-	    <ul>
-		    <li>define acceptable and expected standards of behaviour</lii>
-	    <li>provide a benchmark</li>
-	    <li>ensure transparency in managing moderation</li>
-	    <li>ensure and environment where people can participate without fear of harrassment</li>
-<li>contribute to the identity of the organisation<li></ul>
+<head>
+  <meta charset="utf-8">
+  <title>Positive Work Environment at W3C: Code of Ethics and Professional Conduct</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+  <script class='remove'>
+    // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
+    var respecConfig = {
+      specStatus: "base",
+      shortName: "pwe",
+      editors: [{
+        name: "Tzviya Siegman",
+        company: "Wiley",
+        companyURL: "https://www.wiley.com",
+        w3cid: 65542
+      }, {
+        name: "An Qi Li",
+        company: "Ali Baba",
+        companyURL: "https://www.alibaba.com",
+        w3cid: 40190
+      }],
+      processVersion: 2018,
+      includePermalinks: false,
+      permalinkEdge: true,
+      permalinkHide: false,
+      diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+      github: {
+        repoURL: "https://github.com/w3c/PWETF/",
+        branch: "master"
+      },
+    };
+  </script>
+</head>
 
-    </section>
-    <section id="sotd">
-      <p>
-        This is an unofficial proposal.
-	Refer to <a href="https://www.w3.org/Consortium/cepc/">Code of
-	Ethics and Professional Conduct</a> for the operational
-	version.
-      </p>
-    </section>
+<body>
+  <section id="abstract">
 
-    <section id="introduction">
-      <h2>Introduction</h2>
+    <p>A <strong>Code of Ethics and Professional Conduct</strong> is useful to
+      define accepted and acceptable behaviors and to promote high standards of
+      professional practice. The goals of this code are to:</p>
+    <ul>
+      <li>define acceptable and expected standards of behaviour</li>
+      <li>provide a benchmark</li>
+      <li>ensure transparency in managing moderation</li>
+      <li>ensure and environment where people can participate without fear of harrassment</li>
+      <li>contribute to the identity of the organisation</li>
+    </ul>
 
-<p>W3C is a <strong>growing and global community</strong> where participants
-choose to work together, and it is committed to maintaining a positive working environment, where each participant feels appreciated and respected and where everyone adheres to the same high level of standards of personal behavior. In that process we experience differences in language, location, nationality, and experience. In such a diverse environment, 
-misunderstandings and disagreements happen, which in most cases can be resolved
-informally.</p>
-	    <ul>
-<li> W3C community participants should treat each other with respect and professionalism and be mindful of cultural differences.</li>
-<li>W3C community participants should communicate constructively and avoid insulting, unwelcome or demeaning behavior.</li>
-<li>W3C strictly prohibits discrimination, intimidation, harassment, and bullying of any kind and on any basis.</li>
-<li>W3C will act formally to eliminate abusive behavior in any form, whether it is verbal, physical, sexual, or implied.</li>
-		    </ul>
+  </section>
+  <section id="sotd">
+    <p>
+      This is an unofficial proposal.
+      Refer to <a href="https://www.w3.org/Consortium/cepc/">Code of
+        Ethics and Professional Conduct</a> for the operational
+      version.
+    </p>
+  </section>
 
-<p>A <strong>Code of Ethics and Professional Conduct</strong> is useful to
-define accepted and acceptable behaviors and to promote high standards of
-professional practice. The goal of this code of conduct is to ensure transparency in moderation of the working group and to ensure that the working group is an environment where everyone can participate without fear of harassment.It also provides a benchmark for self evaluation and
-acts as a vehicle for better identity of the organization.</p>
+  <section id="introduction">
+    <h2>Introduction</h2>
 
-<p>This code (<strong>CEPC</strong>), complemented by a set of <a
-href="/Consortium/pwe/#Procedures">Procedures</a>, applies to any member of the
-W3C community – staff, members, invited experts, participants in W3C
-meetings, W3C teleconferences, W3C mailing lists, W3C conference or W3C
-functions, etc. Note that this code complements rather than replaces legal
-rights and obligations pertaining to any particular situation.</p>
+    <p>W3C is a <strong>growing and global community</strong> where participants
+      choose to work together, and it is committed to maintaining a positive working environment, where each participant
+      feels appreciated and respected and where everyone adheres to the same high level of standards of personal
+      behavior. In that process we experience differences in language, location, nationality, and experience. In such a
+      diverse environment,
+      misunderstandings and disagreements happen, which in most cases can be resolved
+      informally.</p>
+    <ul>
+      <li> W3C community participants should treat each other with respect and professionalism and be mindful of
+        cultural differences.</li>
+      <li>W3C community participants should communicate constructively and avoid insulting, unwelcome or demeaning
+        behavior.</li>
+      <li>W3C strictly prohibits discrimination, intimidation, harassment, and bullying of any kind and on any basis.
+      </li>
+      <li>W3C will act formally to eliminate abusive behavior in any form, whether it is verbal, physical, sexual, or
+        implied.</li>
+    </ul>
 
-<p><a href="/Consortium/pwe/#Education">Education and training materials</a>
-are available from the <a href="/Consortium/pwe/">Positive Work Environment
-public homepage</a>.</p>
-</section>
+    <p>A <strong>Code of Ethics and Professional Conduct</strong> is useful to
+      define accepted and acceptable behaviors and to promote high standards of
+      professional practice. The goal of this code of conduct is to ensure transparency in moderation of the working
+      group and to ensure that the working group is an environment where everyone can participate without fear of
+      harassment.It also provides a benchmark for self evaluation and
+      acts as a vehicle for better identity of the organization.</p>
 
-<section>
-<h2>Statement of Intent</h2>
+    <p>This code (<strong>CEPC</strong>), complemented by a set of <a href="/Consortium/pwe/#Procedures">Procedures</a>,
+      applies to any member of the
+      W3C community – staff, members, invited experts, participants in W3C
+      meetings, W3C teleconferences, W3C mailing lists, W3C conference or W3C
+      functions, etc. Note that this code complements rather than replaces legal
+      rights and obligations pertaining to any particular situation.</p>
 
-<p>W3C is committed to maintain a
-<strong>positive</strong> work environment. This commitment calls for a
-workplace where <a>participants</a> at all levels
-<strong>behave</strong> according to the rules of the following code. A
-foundational concept of this code is that <strong>we all share
-responsibility</strong> for our <a>work environment</a>.</p>
-</section>
+    <p><a href="/Consortium/pwe/#Education">Education and training materials</a>
+      are available from the <a href="/Consortium/pwe/">Positive Work Environment
+        public homepage</a>.</p>
+  </section>
 
-<section>
-<h2>Code</h2>
+  <section>
+    <h2>Statement of Intent</h2>
 
-	<h3 id="unacceptablebehaviour">
-        <strong>Unacceptable behaviour</strong>
-      </h3>
+    <p>W3C is committed to maintain a
+      <strong>positive</strong> work environment. This commitment calls for a
+      workplace where <a>participants</a> at all levels
+      <strong>behave</strong> according to the rules of the following code. A
+      foundational concept of this code is that <strong>we all share
+        responsibility</strong> for our <a>work environment</a>.</p>
+  </section>
 
-	<div class="note" title="This section is a work in progress">
-	<p>Including "unnacceptable behavior is new to CEPC. While we agree on the intent of this section, discussions about specific language, extent, specificity, and placement are still underway.</p>
-	</div>
-      <p>Some behaviors run counter to the Code of Ethics and Professional Conduct. This list of unacceptable behaviors does not cover every case. Each person you interact with is unique, and behavior must be assessed on an individual level. Ensuring that your behavior does not have a negative impact is your responsibility. W3C strictly prohibits discrimination, intimidation, harassment, and bullying of any kind and on any basis.</p>
-		
+  <section>
+    <h2>Code</h2>
+
+    <h3 id="unacceptablebehaviour">
+      <strong>Unacceptable behaviour</strong>
+    </h3>
+
+    <div class="note" title="This section is a work in progress">
+      <p>Including "unnacceptable behavior is new to CEPC. While we agree on the intent of this section, discussions
+        about specific language, extent, specificity, and placement are still underway.</p>
+    </div>
+    <p>Some behaviors run counter to the Code of Ethics and Professional Conduct. This list of unacceptable behaviors
+      does not cover every case. Each person you interact with is unique, and behavior must be assessed on an individual
+      level. Ensuring that your behavior does not have a negative impact is your responsibility. W3C strictly prohibits
+      discrimination, intimidation, harassment, and bullying of any kind and on any basis.</p>
+
     <p>All complaints will be taken seriously and will receive a response.</p>
 
+    <ul>
+      <li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental
+        illness,
+        neurotype, physical appearance, body, age, race, socio-economic status, ethnicity, nationality, language, or
+        religion</li>
+
+      <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food,
+        health,
+        parenting, drugs, and employment</li>
+
+      <li>Misgendering someone by deliberately referring to a person using their wrong pronouns. Or by using someone's
+        proper names or other terms that person has asked not to be used, also known as dead-naming.</li>
+
+      <li>Gratuitous or off-topic sexual images or behaviour in spaces where they are not appropriate</li>
+
+      <li>Physical contact and simulated physical contact (e.g., textual descriptions like “hug” or “backrub”) without
+        consent
+        or after a request to stop</li>
+
+      <li>Threats of violence</li>
+
+      <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage
+        in self-harm</li>
+
+      <li>Deliberate intimidation</li>
+
+      <li>Stalking or following</li>
+
+      <li>Harassing photography or recording, including logging online activity for harassment purposes</li>
+
+      <li>Sustained disruption of discussion</li>
+
+      <li>Unwelcome sexual attention</li>
+
+      <li>Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with
+        others</li>
+
+      <li>Continued one-on-one communication after requests to cease</li>
+
+      <li>Deliberate outing of any aspect of a person’s identity without their consent except as necessary to protect
+        other
+        community members or other vulnerable people from intentional abuse</li>
+
+      <li>Publication of non-harassing private communication without consent by the involved parties</li>
+
+      <li>Use of coded language (also known as "dog whistles") used to rally support for hate groups or to intimidate
+        vulnerable groups. used to rally support for hate groups and to intmidate vulnerable groups.</li>
+
+      <li>Microaggressions, which are small comments or questions, either intentional or unintentional, that marginalize
+        people
+        by communicating hostile, derogatory, or negative beliefs. Examples include
+
+
+        <ul>
+          <li>Patronizing language or behavior
+            <ul>
+              <li>Be aware that, regardless of the speaker's intentions, some phrases or constructions lead people to
+                expect a patronizing statement to follow, and avoid such phrases. For example, beginning an interjection
+                with "Well actually..." can set this expectation, and be taken as a sign of disrespect.</li>
+
+              <li>Assuming without asking that particular people or groups need concepts defined or explained to them.
+                (It’s
+                great to be sensitive to the fact that people may not be familiar with technical terms you use every
+                day,
+                but assuming that people are uninformed can come across as patronizing.)</li>
+
+              <li>Assuming that particular groups of people are technically unskilled (“So easy your grandmother could
+                do it.”)</li>
+            </ul>
+          </li>
+
+          <li>Repeatedly interrupting or talking over someone else</li>
+
+          <li>Feigning surprise at someone’s lack of knowledge or awareness about a topic</li>
+
+          <li>The use of racially charged language to describe an individual or thing (such as “thug” or “ghetto”)</li>
+
+          <li>Referring to an individual in a way that demeans or challenges the validity of their racial identity</li>
+
+          <li>Mocking someone’s real or perceived accent or first language</li>
+        </ul>
+      </li>
+
+      <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct.</li>
+    </ul>
+
+    <p>The enforcers of this Code should prioritise the safety of individuals within marginalised communities over the
+      comfort of others,
+      and reserve the rights not to take further actions on complaints regarding:</p>
+
+    <ul>
+      <li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
+
+      <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with
+        you.”</li>
+
+      <li>Communication in a tone you don’t find congenial</li>
+
+      <li>Criticisms of racist, sexist, cissexist, or otherwise oppressive behaviour or assumptions</li>
+    </ul>
+
+    <h3>Expected Behavior</h3>
+    <div class="note" title="This section is a work in progress">
+
       <ul>
-        <li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness,
-          neurotype, physical appearance, body, age, race, socio-economic status, ethnicity, nationality, language, or religion</li>
-
-        <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health,
-          parenting, drugs, and employment</li>
-
-        <li>Misgendering someone by deliberately referring to a person using their wrong pronouns. Or by using someone's proper names or other terms that person has asked not to be used, also known as dead-naming.</li>
-
-        <li>Gratuitous or off-topic sexual images or behaviour in spaces where they are not appropriate</li>
-
-        <li>Physical contact and simulated physical contact (e.g., textual descriptions like “hug” or “backrub”) without consent
-          or after a request to stop</li>
-
-        <li>Threats of violence</li>
-
-        <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
-
-        <li>Deliberate intimidation</li>
-
-        <li>Stalking or following</li>
-
-        <li>Harassing photography or recording, including logging online activity for harassment purposes</li>
-
-        <li>Sustained disruption of discussion</li>
-
-        <li>Unwelcome sexual attention</li>
-
-        <li>Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others</li>
-
-        <li>Continued one-on-one communication after requests to cease</li>
-
-        <li>Deliberate outing of any aspect of a person’s identity without their consent except as necessary to protect other
-          community members or other vulnerable people from intentional abuse</li>
-
-        <li>Publication of non-harassing private communication without consent by the involved parties</li>
-
-        <li>Use of coded language (also known as "dog whistles") used to rally support for hate groups or to intimidate vulnerable groups. used to rally support for hate groups and to intmidate vulnerable groups.</li>
-
-        <li>Microaggressions, which are small comments or questions, either intentional or unintentional, that marginalize people
-          by communicating hostile, derogatory, or negative beliefs. Examples include
-
-
-          <ul>
-            <li>Patronizing language or behavior
-
-
-              <ul>
-                <li>Be aware that, regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow, and avoid such phrases. For example, beginning an interjection with "Well actually..." can set this expectation, and be taken as a sign of disrespect.</li>
-
-                <li>Assuming without asking that particular people or groups need concepts defined or explained to them. (It’s
-                  great to be sensitive to the fact that people may not be familiar with technical terms you use every day,
-                  but assuming that people are uninformed can come across as patronizing.)</li>
-
-                <li>Assuming that particular groups of people are technically unskilled (“So easy your grandmother could do it.”)</li>
-              </ul>
-            </li>
-
-            <li>Repeatedly interrupting or talking over someone else</li>
-
-            <li>Feigning surprise at someone’s lack of knowledge or awareness about a topic</li>
-
-            <li>The use of racially charged language to describe an individual or thing (such as “thug” or “ghetto”)</li>
-
-            <li>Referring to an individual in a way that demeans or challenges the validity of their racial identity</li>
-
-            <li>Mocking someone’s real or perceived accent or first language</li>
-          </ul>
+        <li>Treat each other with <a>respect</a>, professionalism,
+          fairness, and sensitivity to our many differences and strengths, including
+          in situations of high pressure and urgency.</li>
+        <li><strong>Appreciate and Accommodate Our Similarities and Differences</strong> We come from many cultures and
+          backgrounds, ways of life, and standard of behavior. Cultural differences can encompass everything from
+          official religious observances to personal habits to clothing. Be respectful of people with different
+          practices, attitudes, and beliefs. To help us achieve and maintain these high standards, each individual
+          participant is expected to share responsibility for our work environment by adhering to the following
+          behavioral guidelines:
         </li>
 
-        <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct.</li>
+        <li><strong>Respect.</strong> We are a large community of people who are passionate about our work, sometimes
+          holding strong opinions and beliefs. We are committed to dealing with each other with courtesy, respect, and
+          dignity at all times. Misunderstandings and disagreements do happen. When conflicts arise, we are expected
+          to resolve them maintaining that courtesy, respect, and dignity, even when emotions are heightened.</li>
+
+        <li><strong>Be inclusive and Promote Diversity.</strong> Seek diverse perspectives. Diversity of views and of
+          people powers innovation, even if it is not always comfortable. Encourage all voices. Help new perspectives
+          be heard and listen actively. If you find yourself dominating a discussion, it is especially important to
+          step back and encourage other voices to join in. Provide alternative ways to contribute.</li>
+
+        <li>Be aware of how much time is taken up by dominant members of the group. </li>
+
+        <li>Be aware that displays of affection may complicate professional relationships. For some cultures, overtly
+          friendly disposition towards another participant involving body contact (e.g.: hugging, touching on the arm
+          or shoulder, or kissing) is uncommon and may be perceived as an invasion of personal space, or as unwelcome
+          advances. Work to eliminate your own biases, prejudices and discriminatory practices. </li>
+
+        <li>Think of others’ needs from their point of view. Use preferred names, titles (including pronouns) and the
+          appropriate tone of voice. Therefore, be formal and conservative in what you do and liberal in what you
+          accept from others and acknowledge the contributions of your peers. At least until a truly friendly
+          atmosphere and relationships are established.</li>
+
+        <li>Be sensitive to language differences. English is the default language of the W3C. However, only some of us
+          are native English speakers. Many participants speak English as a second (or third) language. People who
+          communicate in non-native language often struggle to understand fast and/or quiet speech, and tend to speak
+          louder than they usually would when communicating in their native tongue. If someone struggles to express
+          his thoughts, help ensure their ideas are adequately expressed, heard, and granted thorough consideration.
+        </li>
+
+        <li>Confidentiality and privacy. Sometimes, matters we discuss may fall under various <a
+            href="https://www.w3.org/2019/Process-20190301/#confidentiality-levels">confidentiality</a> agreements and
+            strict adherence to these agreements is expected. In addition, certain pieces of information disclosed in a
+            group setting may be private in nature, or we may inadvertently learn confidential information accidentally
+            disclosed by other participants. Please exercise good judgment, and make reasonable efforts to protect
+            privacy and confidentiality of all participants.
+        </li>
       </ul>
+    </div>
+  </section>
+    
+  <section id="Reporting">
+    <h2>Reporting</h2>
+    <p>Concerns about potential violations of the code of conduct should be reported to a W3C Ombudsperson as
+      outlined in the complementary <a href="https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a>
+        document.</p>
+  </section>
+  <section id="mistake">
+    <h2>If you've done something improper</h2>
+    <p>As we engage in diverse communities we may accidentally cause offense, whether through using unknowingly
+      offensive terminology or through missing social cues.</p>
+    <p>If you realise (or are told) that you have offended someone then take the appropriate steps:
+      <ol>
+        <li>Acknowledge that you've done something improper</li>
+        <li>Briefly apologize. Don't try to explain yourself or minimise the issue.</li>
+        <li>If possible, edit your message, restate your communication in a better way or withdraw your statement.
+          Publicly revising your statement helps define the culture for others.</li>
+      </ol>
 
-      <p>The enforcers of this Code should prioritise the safety of individuals within marginalised communities over the comfort of others,
-        and reserve the rights not to take further actions on complaints regarding:</p>
+        <p>Alice: “Yeah I used X and it was really crazy!” Eve: “Hey, could you not use that word? What about
+          ‘ridiculous’ instead?” Alice: “oh sorry, sure.” -> edits old message to say “Yeah I used X and it was really
+          confusing!”</p>
+        <p>This will allow conversation to quickly continue without any need of further action or escalating the
+          situation.</p>
+        <p>If you don't understand what you did wrong, assume the the hurt party has good cause and accept it. We cannot
+          know everyone's background and should do our best to avoid harm. You are welcome to discuss it with a W3C
+          ombudsperson later.</p>
 
-      <ul>
-        <li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
+  </section>
 
-        <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
+  <section id="glossary">
 
-        <li>Communication in a tone you don’t find congenial</li>
+    <h2>Glossary</h2>
+    <div class="note" title="not for review at this time">This glossary has not been edited. A later draft will include
+      an updated glossary.</div>
+    <dl>
+      <dt><dfn data-lt="demeaning|demean">Demeaning behavior</dfn></dt>
+      <dd>is acting in a way that reduces another person's dignity, sense of
+        self-worth or respect within the community. </dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="discriminate">Discrimination</dfn></dt>
+      <dd>is the prejudicial treatment of an individual based on criteria such
+        as: physical appearance, race, ethnic origin, genetic differences,
+        national or social origin, name, religion, gender, sexual orientation,
+        family or health situation, pregnancy, disability, age, education,
+        wealth, domicile, political view, morals, employment, or union
+        activity.</dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="insulting|insult">Insulting behavior</dfn></dt>
+      <dd>is treating another person with scorn or disrespect. </dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="acknowledge">Acknowledgement</dfn></dt>
+      <dd>is a record of the origin(s) and author(s) of a contribution.</dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="harass">Harassment</dfn></dt>
+      <dd>is any conduct, verbal or physical, that has the intent or effect of
+        interfering with an individual, or that creates an intimidating, hostile,
+        or offensive environment. </dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="leadership">Leadership position</dfn></dt>
+      <dd>includes group Team contacts, group Chairs, W3C management, and
+        Advisory Board members.</dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="participants">Participant</dfn></dt>
+      <dd>includes the following persons:</dd>
+      <dd>
+        <ul>
+          <li>W3C Team (employees, contractors, fellows)</li>
+          <li>W3C group participants (members and invited experts)</li>
+          <li>Advisory Committee Representatives (and their guests)</li>
+          <li>W3C Offices staff </li>
+          <li>Anyone from the Public partaking in the W3C work environment (e.g.
+            comment on our specs or email us, attend our conferences, functions,
+            etc)</li>
+        </ul>
+      </dd>
+      <dt><dfn>Respect</dfn></dt>
+      <dd>is the genuine consideration you have for someone (if only because of
+        their status as participant in W3C, like yourself), and that you show by
+        treating them in a polite and kind way.</dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="sexually harass">Sexual harassment</dfn></dt>
+      <dd>includes visual displays of degrading sexual images, sexually
+        suggestive conduct, offensive remarks of a sexual nature, requests for
+        sexual favors, unwelcome physical contact, and sexual assault.</dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="unwelcome">Unwelcome behavior</dfn></dt>
+      <dd>Hard to define? Some questions to ask yourself are:
+        <ul>
+          <li>how would I feel if I were in the position of the recipient?</li>
+          <li>would my spouse, parent, child, sibling or friend like to be
+            treated this way?</li>
+          <li>would I like an account of my behavior published in the
+            organization's newsletter? </li>
+          <li>could my behavior offend or hurt other members of the work
+            group?</li>
+          <li>could someone misinterpret my behavior as intentionally harmful or
+            harassing?</li>
+          <li>would I treat my boss or a person I admire at work like that ?</li>
+        </ul>
+        <p><em>Summary</em>: if you are unsure whether something might be welcome
+          or unwelcome, don't do it.</p>
+      </dd>
+    </dl>
+    <dl>
+      <dt><dfn>Unwelcome sexual advance</dfn></dt>
+      <dd>includes requests for sexual favors, and other verbal or physical
+        conduct of a sexual nature, where:
+        <ul>
+          <li>submission to such conduct is made either explicitly or implicitly
+            a term or condition of an individual's employment, </li>
+          <li>submission to or rejection of such conduct by an individual is used
+            as a basis for employment decisions affecting the individual,</li>
+          <li>such conduct has the purpose or effect of unreasonably interfering
+            with an individual's work performance or creating an intimidating
+            hostile or offensive working environment.</li>
+        </ul>
+      </dd>
+    </dl>
+    <dl>
+      <dt><dfn data-lt="bully">Workplace Bullying</dfn></dt>
+      <dd>is a tendency of individuals or groups to use persistent aggressive or
+        unreasonable behavior (e.g. verbal or written abuse, offensive conduct or
+        any interference which undermines or impedes work) against a co-worker or
+        any professional relations.</dd>
+    </dl>
+    <dl>
+      <dt><dfn>Work Environment</dfn></dt>
+      <dd>is the set of all available means of collaboration, including, but not
+        limited to messages to mailing lists, private correspondence, Web pages,
+        chat channels, phone and video teleconferences, and any kind of
+        face-to-face meetings or discussions.</dd>
+    </dl>
+  </section>
 
-        <li>Criticisms of racist, sexist, cissexist, or otherwise oppressive behaviour or assumptions</li>
-      </ul>
+  <section id="Feedback>">
 
-	<h3>Expected Behavior</h3>
-	<div class="note" title="This section is a work in progress">
-	
-<ul>
-  <li>Treat each other with <a>respect</a>, professionalism,
-    fairness, and sensitivity to our many differences and strengths, including
-    in situations of high pressure and urgency.</li>
-  <li><strong>Appreciate and Accommodate Our Similarities and Differences</strong>We come from many cultures and backgrounds, ways of life, and standard of behavior. Cultural differences can encompass everything from official religious observances to personal habits to clothing. Be respectful of people with different practices, attitudes, and beliefs. To help us achieve and maintain these high standards, each individual participant is expected to share responsibility for our work environment by adhering to the following behavioral guidelines:
-</li>
-	
-	
-	<ul>
-		<li><strong>Respect.</strong> We are a large community of people who are passionate about our work, sometimes holding strong opinions and beliefs. We are committed to dealing with each other with courtesy, respect, and dignity at all times. Misunderstandings and disagreements do happen. When conflicts arise, we are expected to resolve them maintaining that courtesy, respect, and dignity, even when emotions are heightened.</li>
-		
-		<li><strong>Be inclusive and Promote Diversity.</strong> Seek diverse perspectives. Diversity of views and of people powers innovation, even if it is not always comfortable. Encourage all voices. Help new perspectives be heard and listen actively. If you find yourself dominating a discussion, it is especially important to step back and encourage other voices to join in. Provide alternative ways to contribute.</li>
-		
-		<li>Be aware of how much time is taken up by dominant members of the group.  </li>
-		
-  <li>Be aware that displays of affection may complicate professional relationships. For some cultures, overtly friendly disposition towards another participant involving body contact (e.g.: hugging, touching on the arm or shoulder, or kissing) is uncommon and may be perceived as an invasion of personal space, or as unwelcome advances. Work to eliminate your own biases, prejudices and discriminatory practices. </li>
+    <h2>Feedback &amp; Status</h2>
 
-<li>Think of others’ needs from their point of view. Use preferred names, titles (including pronouns) and the appropriate tone of voice. Therefore, be formal and conservative in what you do and liberal in what you accept from others and acknowledge the contributions of your peers. At least until a truly friendly atmosphere and relationships are established.</li>
+    <h3>Feedback</h3>
 
-<li>Be sensitive to language differences. English is the default language of the W3C. However, only some of us are native English speakers. Many participants speak English as a second (or third) language. People who communicate in non-native language often struggle to understand fast and/or quiet speech, and tend to speak louder than they usually would when communicating in their native tongue. If someone struggles to express his thoughts, help ensure their ideas are adequately expressed, heard, and granted thorough consideration.</li>
+  </section>
 
-<li>Confidentiality and privacy. Sometimes, matters we discuss may fall under various <a href="https://www.w3.org/2019/Process-20190301/#confidentiality-levels>confidentiality"</a>agreements and strict adherence to these agreements is expected. In addition, certain pieces of information disclosed in a group setting may be private in nature, or we may inadvertently learn confidential information accidentally disclosed by other participants. Please exercise good judgment, and make reasonable efforts to protect privacy and confidentiality of all participants.</li>
-</ul>
-</section>
-	  
-<section id="Reporting">
-	<h2>Reporting</h2>
-	<p>Concerns about potential violations of the code of conduct should be reported to a W3C Ombudsperson as outlined in the complementary <a href="https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a> document.</p>
-	  </section>
-	  <section id="mistake">
-	<h2>If you've done something improper</h2>
-	<p>As we engage in diverse communities we may accidentally cause offense, whether through using unknowingly offensive terminology or through missing social cues.</p>
-<p>If you realise (or are told) that you have offended someone then take the appropriate steps:
-<ol>
-	<li>Acknowledge that you've done something improper</li>
-	<li>Briefly apologize. Don't try to explain yourself or minimise the issue.</li>
-<li>If possible, edit your message, restate your communication in a better way or withdraw your statement. Publicly revising your statement helps define the culture for others.</li></ul>
+</body>
 
-	<p>Alice: “Yeah I used X and it was really crazy!” Eve: “Hey, could you not use that word? What about ‘ridiculous’ instead?” Alice: “oh sorry, sure.” -> edits old message to say “Yeah I used X and it was really confusing!”</p>
-<p>This will allow conversation to quickly continue without any need of further action or escalating the situation.</p>
-<p>If you don't understand what you did wrong, assume the the hurt party has good cause and accept it. We cannot know everyone's background and should do our best to avoid harm. You are welcome to discuss it with a W3C ombudsperson later.</p>
-	
-	  </section>
-
-<section id="glossary">
-	
-<h2>Glossary</h2>
-	<div class="note" title="not for review at this time">This glossary has not been edited. A later draft will include an updated glossary.</div>
-<dl>
-  <dt><dfn data-lt="demeaning|demean">Demeaning behavior</dfn></dt>
-    <dd>is acting in a way that reduces another person's dignity, sense of
-      self-worth or respect within the community. </dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="discriminate">Discrimination</dfn></dt>
-    <dd>is the prejudicial treatment of an individual based on criteria such
-      as: physical appearance, race, ethnic origin, genetic differences,
-      national or social origin, name, religion, gender, sexual orientation,
-      family or health situation, pregnancy, disability, age, education,
-      wealth, domicile, political view, morals, employment, or union
-    activity.</dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="insulting|insult">Insulting behavior</dfn></dt>
-    <dd>is treating another person with scorn or disrespect. </dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="acknowledge">Acknowledgement</dfn></dt>
-    <dd>is a record of the origin(s) and author(s) of a contribution.</dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="harass">Harassment</dfn></dt>
-    <dd>is any conduct, verbal or physical, that has the intent or effect of
-      interfering with an individual, or that creates an intimidating, hostile,
-      or offensive environment. </dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="leadership">Leadership position</dfn></dt>
-    <dd>includes group Team contacts, group Chairs, W3C management, and
-      Advisory Board members.</dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="participants">Participant</dfn></dt>
-    <dd>includes the following persons:</dd>
-    <dd><ul>
-        <li>W3C Team (employees, contractors, fellows)</li>
-        <li>W3C group participants (members and invited experts)</li>
-        <li>Advisory Committee Representatives (and their guests)</li>
-        <li>W3C Offices staff </li>
-        <li>Anyone from the Public partaking in the W3C work environment (e.g.
-          comment on our specs or email us, attend our conferences, functions,
-          etc)</li>
-      </ul>
-    </dd>
-  <dt><dfn>Respect</dfn></dt>
-    <dd>is the genuine consideration you have for someone (if only because of
-      their status as participant in W3C, like yourself), and that you show by
-      treating them in a polite and kind way.</dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="sexually harass">Sexual harassment</dfn></dt>
-    <dd>includes visual displays of degrading sexual images, sexually
-      suggestive conduct, offensive remarks of a sexual nature, requests for
-      sexual favors, unwelcome physical contact, and sexual assault.</dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="unwelcome">Unwelcome behavior</dfn></dt>
-    <dd>Hard to define? Some questions to ask yourself are: 
-      <ul>
-        <li>how would I feel if I were in the position of the recipient?</li>
-        <li>would my spouse, parent, child, sibling or friend like to be
-          treated this way?</li>
-        <li>would I like an account of my behavior published in the
-          organization's newsletter? </li>
-        <li>could my behavior offend or hurt other members of the work
-        group?</li>
-        <li>could someone misinterpret my behavior as intentionally harmful or
-          harassing?</li>
-        <li>would I treat my boss or a person I admire at work like that ?</li>
-      </ul>
-      <p><em>Summary</em>: if you are unsure whether something might be welcome
-      or unwelcome, don't do it.</p>
-    </dd>
-</dl>
-<dl>
-  <dt><dfn>Unwelcome sexual advance</dfn></dt>
-    <dd>includes requests for sexual favors, and other verbal or physical
-      conduct of a sexual nature, where: 
-      <ul>
-        <li>submission to such conduct is made either explicitly or implicitly
-          a term or condition of an individual's employment, </li>
-        <li>submission to or rejection of such conduct by an individual is used
-          as a basis for employment decisions affecting the individual,</li>
-        <li>such conduct has the purpose or effect of unreasonably interfering
-          with an individual's work performance or creating an intimidating
-          hostile or offensive working environment.</li>
-      </ul>
-    </dd>
-</dl>
-<dl>
-  <dt><dfn data-lt="bully">Workplace Bullying</dfn></dt>
-    <dd>is a tendency of individuals or groups to use persistent aggressive or
-      unreasonable behavior (e.g. verbal or written abuse, offensive conduct or
-      any interference which undermines or impedes work) against a co-worker or
-      any professional relations.</dd>
-</dl>
-<dl>
-  <dt><dfn>Work Environment</dfn></dt>
-    <dd>is the set of all available means of collaboration, including, but not
-      limited to messages to mailing lists, private correspondence, Web pages,
-      chat channels, phone and video teleconferences, and any kind of
-      face-to-face meetings or discussions.</dd>
-</dl>
-    </section>
-
-    <section id="Feedback>">
-
-<h2>Feedback &amp; Status</h2>
-
-<h3>Feedback</h3>
-
-    </section>
-
-  </body>
 </html>


### PR DESCRIPTION
Fixes #58 

Fixes some HTML tags

Unifies whitespace


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/61.html" title="Last updated on Jul 24, 2019, 8:18 AM UTC (323d1c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/61/d8f46a6...323d1c5.html" title="Last updated on Jul 24, 2019, 8:18 AM UTC (323d1c5)">Diff</a>