### PR TITLE
Be sensitive in language used

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,7 @@
         <li>Treat each other with <a>respect</a>, professionalism,
           fairness, and sensitivity to our many differences and strengths, including
           in situations of high pressure and urgency.</li>
+
         <li><strong>Appreciate and Accommodate Our Similarities and Differences</strong> We come from many cultures and
           backgrounds, ways of life, and standard of behavior. Cultural differences can encompass everything from
           official religious observances to personal habits to clothing. Be respectful of people with different
@@ -246,6 +247,14 @@
           behavioral guidelines:
         </li>
 
+        <li><strong>Have empathy when choosing your language with regards to sensitive issues</strong> Many people have
+          ongoing violence in their lives or violence in their past which may cause distress when they are reminded of it.
+          Avoid making jokes or callously mentioning sexual violence such as stalking or sexual assault/rape. In the course
+          of our work we may have to discuss these important issues and how they impact people, when we do so they should
+          be treated with gravity and participants should be appropriately warned in advanced so they can choose to step out
+          of these discussions.
+        </li>
+        
         <li><strong>Respect.</strong> We are a large community of people who are passionate about our work, sometimes
           holding strong opinions and beliefs. We are committed to dealing with each other with courtesy, respect, and
           dignity at all times. Misunderstandings and disagreements do happen. When conflicts arise, we are expected

--- a/index.html
+++ b/index.html
@@ -247,12 +247,8 @@
           behavioral guidelines:
         </li>
 
-        <li><strong>Have empathy when choosing your language with regards to sensitive issues</strong> Many people have
-          ongoing violence in their lives or violence in their past which may cause distress when they are reminded of it.
-          Avoid making jokes or callously mentioning sexual violence such as stalking or sexual assault/rape. In the course
-          of our work we may have to discuss these important issues and how they impact people, when we do so they should
-          be treated with gravity and participants should be appropriately warned in advanced so they can choose to step out
-          of these discussions.
+        <li><strong>Have empathy when discussing sensitive issues</strong>
+          Some participants may have experienced (or been subjected to) various forms of violence in their lives, which may cause distress when they are reminded of it. Avoid making jokes or callously mentioning sexual violence such as stalking or sexual assault; in cases when the need arises to discuss these issues and how they affect people - do so with tact and empathy taking into account the gravity of the situation, and make sure that participants are appropriately warned in advance so they can choose to step out of these discussions.
         </li>
         
         <li><strong>Respect.</strong> We are a large community of people who are passionate about our work, sometimes


### PR DESCRIPTION
To fix #69 

Add a section to expected behaviour to ask people to be sensitive about mentioning sexual violence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/71.html" title="Last updated on Nov 27, 2019, 3:56 PM UTC (5a0f8ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/71/7db0c6c...5a0f8ee.html" title="Last updated on Nov 27, 2019, 3:56 PM UTC (5a0f8ee)">Diff</a>