### PR TITLE
add link to wikipedia local law enforcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
     
   <section id="Reporting">
     <h2>Reporting</h2>
-    <p>If you are concerned about your immediate safety, contact local law enforcement.
+    <p>If you are concerned about your immediate safety, contact <a href="https://en.wikipedia.org/wiki/List_of_emergency_telephone_numbers">local law enforcement</a>.
       For a face to face event you may need to contact venue staff for assistance contacting them.</p>
     <p>You may also contact a W3C ombud who will assist you: <a href="mailto:ombuds@w3.org">ombuds@w3.org</a>.</p>
 
@@ -453,13 +453,7 @@
     </dl>
   </section>
 
-  <section id="Feedback>">
-
-    <h2>Feedback &amp; Status</h2>
-
-    <h3>Feedback</h3>
-
-  </section>
+  
 
 </body>
 


### PR DESCRIPTION
* link to https://en.wikipedia.org/wiki/List_of_emergency_telephone_numbers
* remove generated feedback section


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/73.html" title="Last updated on Nov 27, 2019, 5:42 PM UTC (e305910)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/73/371bd4f...e305910.html" title="Last updated on Nov 27, 2019, 5:42 PM UTC (e305910)">Diff</a>