### PR TITLE
Decsribe role of chairs more

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,9 +335,9 @@
     </ul>
     <h3>After the meeting:</h3>
     <ul>
-      <li>Follow up with affected participants, this may be seperate meetings.</li>
+      <li>Follow up with affected participants, this may be separate meetings.</li>
       <li>The Chair may reach out to an Ombuds for assistance</li>
-      <li>If the Chair needs assistance, they can make use of the Chairs Training program.</li>
+      <li>Further information and resources for Chairs are available via the Chairs Training program.</li>
     </ul>
     
     <p><strong>Note</strong> that the action must be directly related to stopping harm, and must be proportionate.

--- a/index.html
+++ b/index.html
@@ -216,9 +216,9 @@
       <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct.</li>
     </ul>
 
-    <p>This Code prioritises the safety of individuals within marginalised communities over the
+    <p>The enforcers of this Code should prioritise the safety of individuals within marginalised communities over the
       comfort of others,
-      and reserves the right not to take further action on complaints regarding:</p>
+      and reserve the rights not to take further actions on complaints regarding:</p>
 
     <ul>
       <li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
@@ -293,29 +293,56 @@
     
   <section id="Reporting">
     <h2>Reporting</h2>
-    <p>If you are concerned about your immediate safety, contact <a href="https://en.wikipedia.org/wiki/List_of_emergency_telephone_numbers">local law enforcement</a>.
-      For a face to face event you may need to contact venue staff for assistance contacting them.</p>
-    <p>You may also contact a W3C ombud who will assist you: <a href="mailto:ombuds@w3.org">ombuds@w3.org</a>.</p>
+    <p>If you are concerned about your immediate safety, contact 
+      <a href="https://en.wikipedia.org/wiki/List_of_emergency_telephone_numbers">local law enforcement</a>.
+      For a face to face event Chairs and venue staff should provide any necessary assistance contacting them.
+    </p>
+    
+    <p>You may also contact a W3C ombud who will assist you. COntact addresses are included in the
+      <a href="https://www.w3.org/Consortium/pwe/#ombuds">list of current W3c ombuds</a> or you can mail 
+      all ombuds collectively at <a href="mailto:ombuds@w3.org">ombuds@w3.org</a>.
+    </p>
 
     <p>If you have an issue with someone’s behaviour along the lines of this Code then please raise it, there
       are a few potential people you could raise it to depending on your situation and your safety.</p>
 
-    <p>You are welcome to raise issues directly with the <a href="mailto:ombuds@w3.org">Ombuds</a> who
+    <p>You are welcome to raise issues directly with the <a href="https://www.w3.org/Consortium/pwe/#ombuds">Ombuds</a> who
       will assist you. All complaints will be taken seriously and will receive a response.</p>
 
-    <p>If it is applicable, You may instead choose to raise issues with a chair of the group. A group chair will have
-      more context so may be better able to assist you. If they do not feel able to assist you, they should help you raise
+    <p>You may instead choose to raise issues with a chair of the group. A chair generally knows the context of the group
+      so may be better able to assist you. If they do not feel able to assist you, they should help you raise
       the issue with an Ombuds person. You may also ask for them to help you raise it to an Ombuds person immediately
       if you do not feel comfortable contacting the Ombuds directly. 
     </p>
 
-    <p>If you are responsible for a community within the W3C such as a chair of a working group and you witness harassment or
-      any other behaviour which goes against this code you are encouraged to raise issues directly with
-      an <a href="mailto:ombuds@w3.org">Ombuds</a> person who can assist you.
+    <p>If you are in a <a>leadership position</a> and you witness harassment or other 
+      <a href="#unacceptablebehavior">unacceptable behaviour</a> you should raise issues directly with
+      an <a href="https://www.w3.org/Consortium/pwe/#ombuds">Ombuds</a> person who can assist you.
     </p>
-
+    
+    <p>Any person in a <a>leadership position</a> should provide immediate assistance to any participant
+      who wants to contact an ombuds. Failure to do so may increase the harmful consequences of the action being reported.
+    </p>
+    
+    <p>Chairs, Team Contacts and Event Organisers should take such immediate action as they deem necessary in order to stop
+      harmful effects of harassment, bullying, or other <a href="#unacceptablebehaviour">unacceptable behaviour</a>.
+      This action may take many forms, but examples include:
+    </p>
+    
+    <ul>
+      <li>ejecting someone from a meeting or event</li>
+      <li>Blocking them on a mailing list</li>
+      <li>Removing specific comments from an archive, or the harmful parts of such comments</li>
+    </ul>
+    
+    <p><strong>Note</strong> that the action must be directly related to stopping harm, and must be proportionate.
+      People affected may request an ombuds consider whether such actions are unacceptable under the terms of this Code.
+    </p>
+    
     <p>You can read more in the PWETF <a href="https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a>
-        document.</p>
+        document.
+    </p>
+    
   </section>
   <section id="mistake">
     <h2>If you've done something improper</h2>

--- a/index.html
+++ b/index.html
@@ -295,10 +295,10 @@
     <h2>Reporting</h2>
     <p>If you are concerned about your immediate safety, contact 
       <a href="https://en.wikipedia.org/wiki/List_of_emergency_telephone_numbers">local law enforcement</a>.
-      For a face to face event Chairs and venue staff should provide any necessary assistance contacting them.
+      For a face to face event Chairs and venue staff should provide any necessary assistance contacting law enforcement.
     </p>
     
-    <p>You may also contact a W3C ombud who will assist you. Contact addresses are included in the
+    <p>You may also contact a W3C ombuds who will assist you. Contact addresses are included in the
       <a href="https://www.w3.org/Consortium/pwe/#ombuds">list of current W3c ombuds</a> or you can mail 
       all ombuds collectively at <a href="mailto:ombuds@w3.org">ombuds@w3.org</a>.
     </p>
@@ -311,13 +311,13 @@
 
     <p>You may instead choose to raise issues with a chair of the group. A chair generally knows the context of the group
       so may be better able to assist you. If they do not feel able to assist you, they should help you raise
-      the issue with an Ombuds person. You may also ask for them to help you raise it to an Ombuds person immediately
+      the issue with an Ombuds. You may also ask for them to help you raise it to an Ombuds immediately
       if you do not feel comfortable contacting the Ombuds directly. 
     </p>
 
     <p>If you are in a <a>leadership position</a> and you witness harassment or other 
       <a href="#unacceptablebehavior">unacceptable behaviour</a> you should raise issues directly with
-      an <a href="https://www.w3.org/Consortium/pwe/#ombuds">Ombuds</a> person who can assist you.
+      an <a href="https://www.w3.org/Consortium/pwe/#ombuds">Ombuds</a> who can assist you.
     </p>
     
     <p>Any person in a <a>leadership position</a> should provide immediate assistance to any participant
@@ -325,14 +325,19 @@
     </p>
     
     <p>Chairs, Team Contacts and Event Organisers should take such immediate action as they deem necessary in order to stop
-      harmful effects of harassment, bullying, or other <a href="#unacceptablebehaviour">unacceptable behaviour</a>.
-      This action may take many forms, but examples include:
+      <a href="#unacceptablebehaviour">unacceptable behaviour</a>. This action may take many forms, but examples may include:
     </p>
-    
+    <h3>Immediately:</h3>
     <ul>
-      <li>ejecting someone from a meeting or event</li>
-      <li>Blocking them on a mailing list</li>
-      <li>Removing specific comments from an archive, or the harmful parts of such comments</li>
+      <li>Point out if someone is violating the CEPC, to give them the chance to withdraw or edit their statement.</li>
+      <li>Remind participants that meetings & work operate under the CEPC.</li>
+      <li>Asking someone to leave a meeting, or a conversation thread.</li>
+    </ul>
+    <h3>After the meeting:</h3>
+    <ul>
+      <li>Follow up with affected participants, this may be seperate meetings.</li>
+      <li>The Chair may reach out to an Ombuds for assistance</li>
+      <li>If the Chair needs assistance, they can make use of the Chairs Training program.</li>
     </ul>
     
     <p><strong>Note</strong> that the action must be directly related to stopping harm, and must be proportionate.

--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
       For a face to face event Chairs and venue staff should provide any necessary assistance contacting them.
     </p>
     
-    <p>You may also contact a W3C ombud who will assist you. COntact addresses are included in the
+    <p>You may also contact a W3C ombud who will assist you. Contact addresses are included in the
       <a href="https://www.w3.org/Consortium/pwe/#ombuds">list of current W3c ombuds</a> or you can mail 
       all ombuds collectively at <a href="mailto:ombuds@w3.org">ombuds@w3.org</a>.
     </p>


### PR DESCRIPTION
fixes #45 (at least, that's the intention).

Clarify that chairs and other in "leadership positions":
1. Are meant to help follow up an issue
2. Should be proactive in doing so
3. Are expected to take immediate proportionate action as necessary to stop a harmful situation from continuing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chaals/PWETF/pull/75.html" title="Last updated on Dec 19, 2019, 5:32 PM UTC (b659a04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/75/60544e7...chaals:b659a04.html" title="Last updated on Dec 19, 2019, 5:32 PM UTC (b659a04)">Diff</a>