### PR TITLE
Punctuation at the end of bulleted elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,16 +187,16 @@
             <ul>
               <li>Be aware that, regardless of the speaker's intentions, some phrases or constructions lead people to
                 expect a patronizing statement to follow, and avoid such phrases. For example, beginning an interjection
-                with "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
+                with "Well, actually..." can set this expectation and be taken as a sign of disrespec</li>
 
               <li>Assuming without asking that particular people or groups need concepts defined or explained to them.
                 (It’s
                 great to be sensitive to the fact that people may not be familiar with technical terms you use every
                 day,
-                but assuming that people are uninformed can come across as patronizing.)</li>
+                but assuming that people are uninformed can come across as patronizing)</li>
 
               <li>Assuming that particular groups of people are technically unskilled (“So easy your grandmother could
-                do it.”)</li>
+                do it”)</li>
             </ul>
           </li>
 
@@ -212,7 +212,7 @@
         </ul>
       </li>
 
-      <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct.</li>
+      <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct</li>
     </ul>
 
     <p>This Code prioritizes the safety of individuals within marginalized communities over the
@@ -223,7 +223,7 @@
       <li>"Reverse" -isms, including "reverse racism," "reverse sexism," and "cisphobia"</li>
 
       <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with
-        you.”</li>
+        you”</li>
 
       <li>Communication in a tone you don’t find congenial</li>
 
@@ -320,15 +320,15 @@
     </p>
     <h3>Immediately:</h3>
     <ul>
-      <li>Pointing out if someone is violating the CEPC to give them the chance to withdraw or edit their statement.</li>
-      <li>Reminding participants that meetings and work operate under the CEPC.</li>
-      <li>Asking someone to leave a meeting, or a conversation thread.</li>
+      <li>Pointing out if someone is violating the CEPC to give them the chance to withdraw or edit their statement</li>
+      <li>Reminding participants that meetings and work operate under the CEPC</li>
+      <li>Asking someone to leave a meeting, or a conversation thread</li>
     </ul>
     <h3>After the meeting:</h3>
     <ul>
-      <li>Following up with affected participants, possibly in separate meetings.</li>
+      <li>Following up with affected participants, possibly in separate meetings</li>
       <li>Reaching out to an Ombudsperson for assistance</li>
-      <li>Further information and resources for Chairs are available via the Chairs Training program.</li>
+      <li>Further information and resources for Chairs are available via the Chairs Training program</li>
     </ul>
     
     <p><strong>Note</strong> that the action must be directly related to stopping harm, and must be proportionate.
@@ -347,9 +347,9 @@
     <p>If you realize (or are told) that you have offended someone then take the appropriate steps:
       <ol>
         <li>Acknowledge that you've done something improper</li>
-        <li>Briefly apologize. Don't try to explain yourself or minimize the issue.</li>
+        <li>Briefly apologize. Don't try to explain yourself or minimize the issue</li>
         <li>If possible, edit your message, restate your communication in a better way or withdraw your statement.
-          Publicly revising your statement helps define the culture for others.</li>
+          Publicly revising your statement helps define the culture for others</li>
       </ol>
 
         <p>Alice: “Yeah I used X and it was really crazy!” Eve: “Hey, could you not use that word? What about
@@ -369,7 +369,7 @@
     <dl>
 
       <dt><dfn data-lt="Acceptable|accepted">Acceptable Behavior</dfn></dt>
-      <dd>Within the W3C, this is behaviour which abides by this Code of Ethics and Professional Conduct</dd>
+      <dd>Within the W3C, this is behavior which abides by this Code of Ethics and Professional Conduct.</dd>
 
       <dt><dfn data-lt="bully">Workplace Bullying</dfn></dt>
       <dd>is a tendency of individuals or groups to use persistent aggressive or
@@ -389,7 +389,7 @@
         <p>
           The belief or assumption that cis people’s gender identities, expressions, and embodiments are more natural and legitimate than those of trans people.
         </p>
-        <p>It is related to Transphobia</p>
+        <p>It is related to Transphobia.</p>
       </dd>
 
       <dt><dfn data-lt="consent">Consent</dfn></dt>
@@ -404,9 +404,9 @@
           If someone asks you to use a name for them you should use it. This includes:
         </p>
         <ul>
-          <li>A trans person, who has changed their name when transitioning.</li>
-          <li>Someone who has changed their name through marriage.</li>
-          <li>Someone who has changed their name for any other reason.</li>
+          <li>A trans person, who has changed their name when transitioning</li>
+          <li>Someone who has changed their name through marriage</li>
+          <li>Someone who has changed their name for any other reason</li>
         </ul>
       </dd>
 
@@ -561,12 +561,12 @@
         conduct of a sexual nature, where:
         <ul>
           <li>submission to such conduct is made either explicitly or implicitly
-            a term or condition of an individual's employment, </li>
+            a term or condition of an individual's employment</li>
           <li>submission to or rejection of such conduct by an individual is used
-            as a basis for employment decisions affecting the individual,</li>
+            as a basis for employment decisions affecting the individual</li>
           <li>such conduct has the purpose or effect of unreasonably interfering
             with an individual's work performance or creating an intimidating
-            hostile or offensive working environment.</li>
+            hostile or offensive working environment</li>
         </ul>
       </dd>
     </dl>


### PR DESCRIPTION
This PR removes most of the punctuation ending bulleted elements (except in the case when a bunch of <li>s are in fact paragraphs and could be <p>s. In this case, it makes sense to leave the periods at the end.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/95.html" title="Last updated on Jan 10, 2020, 9:23 AM UTC (d94bcdc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/95/422571d...d94bcdc.html" title="Last updated on Jan 10, 2020, 9:23 AM UTC (d94bcdc)">Diff</a>