### PR TITLE
swapped definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,6 +786,22 @@
             imbalances within communities to further marginalize groups.
           </p>
         </dd>
+        
+        <dt><dfn data-lt="sexually harass">Sexual harassment</dfn></dt>
+  <dd><p>includes requests for sexual favors, and other verbal or physical
+        conduct of a sexual nature, where:</p>
+        <ul>
+          <li>submission to such conduct is made either explicitly or implicitly
+            a term or condition of an individual's employment</li>
+          <li>submission to or rejection of such conduct by an individual is used
+            as a basis for employment decisions affecting the individual</li>
+          <li>such conduct has the purpose or effect of unreasonably interfering
+            with an individual's work performance or creating an intimidating
+            hostile or offensive working environment</li>
+        </ul>
+      </dd>
+    </dl>
+        
         <dt>
           <dfn>Sexual Orientation</dfn>
         </dt>
@@ -795,17 +811,6 @@
             attracted to in relation to their own gender.
           </p>
         </dd>
-        <dt>
-          <dfn data-lt="sexually harass">Sexual harassment</dfn>
-        </dt>
-        <dd>
-          <p>
-            includes visual displays of degrading sexual images, sexually
-            suggestive conduct, offensive remarks of a sexual nature, requests
-            for sexual favors, unwelcome physical contact, and sexual assault.
-          </p>
-        </dd>
-        <dt>
           <dfn>Socio-economic status</dfn>
         </dt>
         <dd>
@@ -827,27 +832,9 @@
           </p>
         </dd>
         <dt>
-          <dfn>Unwelcome sexual advance</dfn>
-        </dt>
-        <dd>
-          <p>
-            includes requests for sexual favors, and other verbal or physical
-            conduct of a sexual nature, where:
-          </p>
-          <ul>
-            <li>submission to such conduct is made either explicitly or
-            implicitly a term or condition of an individual's employment
-            </li>
-            <li>submission to or rejection of such conduct by an individual is
-            used as a basis for employment decisions affecting the individual
-            </li>
-            <li>such conduct has the purpose or effect of unreasonably
-            interfering with an individual's work performance or creating an
-            intimidating hostile or offensive working environment
-            </li>
-          </ul>
-        </dd>
-      </dl>
+<dt><dfn>Unwelcome sexual advance</dfn></dt>
+      <dd><p>includes visual displays of degrading sexual images, sexually suggestive conduct, offensive remarks of a sexual nature, requests for sexual favors, unwelcome physical contact, and sexual assault.</p></dd>
+    </dl>
     </section>
     <section id="Attribution">
       <h2>


### PR DESCRIPTION
* moved sexual harassment before sexual orientation (alpha)
* swapped sexual harassment and unwelcome sexual advance definitions
* fixes #78
* replaces #105 (after respec fixes merge conflict)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/109.html" title="Last updated on Jan 22, 2020, 8:36 PM UTC (79145db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/109/f744ba1...79145db.html" title="Last updated on Jan 22, 2020, 8:36 PM UTC (79145db)">Diff</a>