### PR TITLE
Copy edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <section id="abstract">
       <p>
         W3C's <cite>Code of Ethics and Professional Conduct</cite> defines
-        accepted and acceptable behaviors and to promote high standards of
+        accepted and acceptable behaviors and promotes high standards of
         professional practice. The goals of this code are to:
       </p>
       <ul>
@@ -169,7 +169,7 @@
           that courtesy, respect, and dignity, even when emotions are
           heightened.
           </li>
-          <li>Honesty. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid,  straightforward and frank.</li>
+          <li>Honesty. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid, straightforward, and frank.</li>
           <li>Be inclusive and promote <a>diversity</a>. Seek diverse
           perspectives. Diversity of views and of people powers innovation,
           even if it is not always comfortable. Encourage all voices. Help new
@@ -222,7 +222,7 @@
           Unacceptable behavior
         </h3>
         <p>
-          <dfn>Unacceptable behaviors</dfn> behaviors run counter to the Code
+          <dfn>Unacceptable behaviors</dfn> run counter to the Code
           of Ethics and Professional Conduct. This list of <a>unacceptable
           behaviors</a> does not cover every case. Each person you interact
           with is unique, and behavior must be assessed on an individual level.
@@ -497,7 +497,7 @@
         </dt>
         <dd>
           <p>
-            is a tendency of individuals or groups to use persistent aggressive
+            A tendency of individuals or groups to use persistent aggressive
             or unreasonable behavior (e.g. verbal or written abuse, offensive
             conduct or any interference which undermines or impedes work)
             against a co-worker or any professional relations.
@@ -562,8 +562,8 @@
         </dt>
         <dd>
           <p>
-            is acting in a way that reduces another person's dignity, sense of
-            self-worth or respect within the community.
+            Acting in a way that reduces another person's dignity, sense of
+            self-worth, or respect within the community.
           </p>
         </dd>
         <dt>
@@ -571,7 +571,7 @@
         </dt>
         <dd>
           <p>
-            is the prejudicial treatment of an individual based on criteria
+            The prejudicial treatment of an individual based on criteria
             such as: physical appearance, race, ethnic origin, genetic
             differences, national or social origin, name, religion, gender,
             sexual orientation, family or health situation, pregnancy,
@@ -617,7 +617,7 @@
         </dt>
         <dd>
           <p>
-            is the practice or policy of including people who might otherwise
+            The practice or policy of including people who might otherwise
             be excluded or marginalized.
           </p>
         </dd>
@@ -626,7 +626,7 @@
         </dt>
         <dd>
           <p>
-            is treating another person with scorn or disrespect.
+            Treating another person with scorn or disrespect.
           </p>
         </dd>
         <dt>
@@ -634,7 +634,7 @@
         </dt>
         <dd>
           <p>
-            is any conduct, verbal or physical, that has the intent or effect
+            Any conduct, verbal or physical, that has the intent or effect
             of interfering with an individual, or that creates an intimidating,
             hostile, or offensive environment.
           </p>
@@ -644,7 +644,7 @@
         </dt>
         <dd>
           <p>
-            are communities which are often overlooked, ignored or denigrated
+            Communities which are often overlooked, ignored or denigrated
             to the detriment of the members of that community. People may often
             be part of multiple communities such as being queer and disabled.
           </p>
@@ -654,7 +654,7 @@
         </dt>
         <dd>
           <p>
-            a person’s condition with regard to their psychological and
+            A person’s condition with regard to their psychological and
             emotional well-being.
           </p>
         </dd>
@@ -677,7 +677,7 @@
         <dd>
           <p>
             Misgendering is addressing someone using gendered words to imply or
-            statement they are a different gender than the one they have asked
+            state they are a different gender than the one they have asked
             to be used.
           </p>
           <p>
@@ -699,7 +699,7 @@
         </dt>
         <dd>
           <p>
-            is one who assists individuals and groups in the resolution of
+            One who assists individuals and groups in the resolution of
             conflicts or concerns. They are a designated neutral who is
             appointed or employed by the W3C to facilitate the informal
             resolution of concerns of <a>participants</a> within the W3C.
@@ -710,7 +710,7 @@
         </dt>
         <dd>
           <p>
-            includes the following persons:
+            Includes the following persons:
           </p>
         </dd>
         <dd>
@@ -734,7 +734,7 @@
           <p>
             Racial prejudice refers to a set of discriminatory or derogatory
             attitudes based on assumptions deriving from perceptions about
-            race, culture, religion and/or skin colour.
+            race, culture, religion, and/or skin colour.
           </p>
         </dd>
         <dt>
@@ -786,9 +786,9 @@
             imbalances within communities to further marginalize groups.
           </p>
         </dd>
-        
+
         <dt><dfn data-lt="sexually harass">Sexual harassment</dfn></dt>
-  <dd><p>includes requests for sexual favors, and other verbal or physical
+  <dd><p>Includes requests for sexual favors, and other verbal or physical
         conduct of a sexual nature, where:</p>
         <ul>
           <li>submission to such conduct is made either explicitly or implicitly
@@ -801,7 +801,7 @@
         </ul>
       </dd>
     </dl>
-        
+
         <dt>
           <dfn>Sexual Orientation</dfn>
         </dt>


### PR DESCRIPTION
Made some small changes to consistency of the usage of the oxford comma, glossary entries, and verb tense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/112.html" title="Last updated on Jan 28, 2020, 8:55 PM UTC (3fadad1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/112/7c19013...3fadad1.html" title="Last updated on Jan 28, 2020, 8:55 PM UTC (3fadad1)">Diff</a>