### PR TITLE
Provide citation for "Fellows"

### DIFF
--- a/index.html
+++ b/index.html
@@ -715,9 +715,12 @@
         </dd>
         <dd>
           <ul>
-            <li>W3C Team (employees, contractors, fellows)
+            <li>W3C Team (employees, contractors, 
+	      <a href=
+	      "https://www.w3.org/Consortium/Process/#Team">
+	      Fellows</a>)
             </li>
-            <li>W3C group <a>participants</a> (members and invited experts)
+            <li>W3C group participants (member representatives and invited experts)
             </li>
             <li>Advisory Committee Representatives (and their guests)
             </li>


### PR DESCRIPTION
The glossary definition of 'participant' uses the W3C-specific term "fellow".  This begs a citation.  And as the term has a specific meaning in our context it should be capitalized.

This edit also drops a circular reference in  the definition of 'participant'.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/113.html" title="Last updated on Feb 4, 2020, 3:08 PM UTC (6238232)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/113/3ea9089...6238232.html" title="Last updated on Feb 4, 2020, 3:08 PM UTC (6238232)">Diff</a>