### PR TITLE
edited ombuds links

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,8 +361,8 @@
         address the issue.
       </p>
       <p>
-        You are welcome to raise issues directly with the <a href=
-        "mailto:ombuds@w3.org">Ombudspeople</a> who will assist you. All
+	You are welcome to raise issues directly with the <a>Ombudspeople</a> as a <a href=
+        "mailto:ombuds@w3.org">group</a> or <a href="https://www.w3.org/Consortium/pwe/#Procedures">individually</a>. All
         complaints will be taken seriously and will receive a response.
       </p>
       <p>
@@ -402,7 +402,7 @@
           <li>Following up with affected participants, possibly in separate
           meetings
           </li>
-          <li>Reaching out to an <a>Ombudsperson</a> for assistance
+          <li>Reaching out to an Ombudsperson for assistance
           </li>
           <li>Further information and resources for Chairs are available via
           the Chairs Training program
@@ -411,7 +411,7 @@
         <p>
           <strong>Note</strong> that the action must be directly related to
           stopping harm, and must be proportionate. People affected may request
-          an <a>Ombudsperson</a> consider whether such actions are unacceptable
+          an Ombudsperson consider whether such actions are unacceptable
           under the terms of this Code.
         </p>
         <p>
@@ -459,7 +459,7 @@
         If you don't understand what you did wrong, assume that the hurt party
         has good cause and accept it. We cannot know everyone's background and
         should do our best to avoid harm. You are welcome to discuss it with a
-        W3C <a>ombudsperson</a> later.
+        W3C <a href="https://www.w3.org/Consortium/pwe/#Procedures">ombudsperson</a> later.
       </p>
     </section>
     <section id="glossary">


### PR DESCRIPTION
* only first mention of ombuds links to glossary
* links to W3C Procedures, which lists all ombuds by name
* response to #126
cc/ @dbaron


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/130.html" title="Last updated on Apr 28, 2020, 12:38 AM UTC (314b340)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/130/dce89a7...314b340.html" title="Last updated on Apr 28, 2020, 12:38 AM UTC (314b340)">Diff</a>