### PR TITLE
Add link for latest adopted CEPC

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
     var respecConfig = {
       specStatus: "base",
+      prevRecURI: "http://www.w3.org/Consortium/cepc",
       shortName: "pwe",
       editors: [{
         name: "Tzviya Siegman",


### PR DESCRIPTION
The Editor's Draft should cite the latest official CEPC as well.  This does that using the respec config.  If someone with more respec skills than I knows a way to have the result say something better than "Latest Recommendation" I'd appreciate learning from you.