### PR TITLE
Explicitly link to the Geek Feminism Wiki and RationalWiki.

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,25 +265,30 @@
           <li>Sustained disruption of discussion. This may include, but
           is not limited to, various common methods of engaging in bad
           faith discourse such as:<ul>
-              <!-- https://geekfeminism.wikia.org/wiki/Concern_troll -->
-              <li>disingenuously expressesing concern in order to
-              undermine or derail a discussion (<dfn>concern
-              trolling</dfn>),
+              <li><dfn>concern trolling</dfn>: disingenuously
+              expressesing concern in order to undermine or derail a
+              discussion, <cite><a href=
+              "https://geekfeminism.wikia.org/wiki/Concern_troll">Geek
+              Feminism Wiki</a></cite>
               </li>
-              <!-- https://rationalwiki.org/wiki/Just_asking_questions -->
-              <li>asking numerous questions about basic concepts in an
-              attempt to derail discussion, to stifle participation, or
-              to provoke a critical response in order to appear a victim
-              (<dfn>sealioning</dfn>),
+              <li><dfn>sealioning</dfn>: asking numerous questions about
+              basic concepts in an attempt to derail discussion, to
+              stifle participation, or to provoke a critical response in
+              order to appear a victim, <cite><a href=
+              "https://rationalwiki.org/wiki/Just_asking_questions">
+              RationalWiki</a></cite>
               </li>
-              <!-- https://rationalwiki.org/wiki/Gish_Gallop -->
-              <li>overwhelming a debate with many weak arguments in an
-              attempt to cause others to waste time refuting them
-              (<dfn>Gish Galloping</dfn>), or
+              <li><dfn>Gish Galloping</dfn>: overwhelming a debate with
+              many weak arguments in an attempt to cause others to waste
+              time refuting them,
+              <cite><a href="https://rationalwiki.org/wiki/Gish_Gallop"
+              >RationalWiki</a></cite>
               </li>
-              <!-- https://rationalwiki.org/wiki/Argumentum_ad_nauseam -->
-              <li>repeatedly making claims already shown to be false
-              (<dfn lang=la>argumentum ad nauseam</dfn>).
+              <li>or
+              <dfn lang=la>argumentum ad nauseam</dfn>: repeatedly
+              making claims already shown to be false. <cite><a
+              href="https://rationalwiki.org/wiki/Argumentum_ad_nauseam"
+              >RationalWiki</a></cite>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
We decided to merge #171 on our call today, and I took an action to post a follow-on PR to surface the wiki links that were previously in HTML comments in that text. This PR does that, and lightly reformats those lines to make the wiki links less jarring.

I tried to match the citation style used elsewhere in the document, e.g. all the Wikipedia links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hober/PWETF/pull/172.html" title="Last updated on Jun 8, 2021, 4:43 PM UTC (0a75838)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/172/7a9e43a...hober:0a75838.html" title="Last updated on Jun 8, 2021, 4:43 PM UTC (0a75838)">Diff</a>