### PR TITLE
Update "editor's draft" URI in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <script class='remove'>
     // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
     var respecConfig = {
-      edDraftURI: "https://github.com/w3c/PWETF/",
+      edDraftURI: "https://w3c.github.io/PWETF/",
       latestVersion: "https://www.w3.org/Consortium/cepc/",
       specStatus: "ED",
       otherLinks: [


### PR DESCRIPTION
The "Latest editor's draft" link should point to the [rendered draft](https://w3c.github.io/PWETF/), not to the GH repo (which is independently referenced later).