### PR TITLE
Adjust order + content of identity characteristics

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,11 +235,7 @@
           <a>Unacceptable behaviors</a> include, but are not limited to:
         </p>
         <ul>
-          <li>Offensive comments related to gender, <a>gender identity</a> and
-          <a>gender expression</a>, sexual orientation, disability (both
-          visible and invisible), mental health, <a>neurotype</a>, physical
-          appearance, body, age, race, socio-economic status, ethnicity,
-          caste, nationality, language, or religion
+          <li>Offensive comments related to socio-economic status, sexual orientation, religion, race, physical appearance, neurotype, nationality, mental health, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age
           </li>
           <li>Unwelcome comments regarding a person’s lifestyle choices and
           practices, including those related to food, health, parenting, drugs,


### PR DESCRIPTION
Due to the impact of race and class on equity, as well as the increasing awareness and resistance to indigenous groups and immigrants, members of the WCAG3 equity sub-group propose that these groups be added to the list of identities. Additionally, some members propose that the order be changed to reverse alpha-order. 

It is not clear if the characteristics were already in a deliberate order. Members of the equity sub-group are concerned that the lack of order may appear to imply a priority. By proposing a reverse alpha-order, we suggest this shows a conscious decision towards equity including by reversing the alphabetical order, since the traditional alpha-order often leads to inequity. If the reverse alpha-order or addition of characteristics have any concerns, please let me know, as I'm certainly open to discourse.

This PR adds the two characteristics, indigeneity and immigration status, and then orders the list in reverse alphabetical order.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jenstrickland/PWETF/pull/209.html" title="Last updated on Aug 31, 2022, 4:10 PM UTC (85663e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/209/be7eeb8...jenstrickland:85663e7.html" title="Last updated on Aug 31, 2022, 4:10 PM UTC (85663e7)">Diff</a>