### PR TITLE
Demonstrating proposed change to Code of Conduct

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>
-      Positive Work Environment at W3C: Code of Ethics and Professional Conduct
+      Positive Work Environment at W3C: Code of Conduct
     </title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"
     defer="defer"></script>
@@ -48,7 +48,7 @@
   <body>
     <section id="abstract">
       <p>
-        W3C's <cite>Code of Ethics and Professional Conduct</cite> defines
+        W3C's <cite>Code of Conduct</cite> defines
         accepted and acceptable behaviors and promotes high standards of
         professional practice. The goals of this code are to:
       </p>
@@ -70,7 +70,7 @@
       <p>
         This is an editors' draft; a Work in Progress which will be submitted to W3C
 	as a proposed update to the currently operational version of the
-	<a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.
+	<a href="https://www.w3.org/Consortium/cepc/">Code of Conduct</a>.
       </p>
     </section>
     <section id="introduction">
@@ -87,9 +87,9 @@
         misunderstandings and disagreements happen, which in most cases can be
         resolved informally.
       </p>
-            <p>
-        W3C's <cite>Code of Ethics and Professional Conduct</cite>
-        (<abbr title="Code of Ethics and Professional Conduct">CEPC</abbr>) is
+      <p>
+        W3C's <cite>Code of Conduct</cite>
+        (<abbr title="Code of Conduct">CoC</abbr>) is
         useful to define accepted and <a>acceptable behaviors</a> and to
         promote high standards of professional practice. The goal of this code
         of conduct is to ensure that W3C is an environment where everyone can
@@ -98,7 +98,7 @@
         of the organization.
       </p>
       <p>
-        The CEPC is complemented by a set of <a href=
+        The CoC is complemented by a set of <a href=
         "https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a>, applies
         to any member of the W3C community – staff, members, invited experts,
         and <a>participants</a> in W3C meetings, W3C teleconferences, W3C
@@ -195,7 +195,7 @@
           liberal in what you accept from others and acknowledge the
           contributions of your peers.
           </li>
-		<li>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
+		      <li>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
           <li>Be sensitive to language differences. English is the default
           language of the W3C. However, only some of us are native English
           speakers. Many <a>participants</a> speak English as a second (or
@@ -241,8 +241,7 @@
           practices, including those related to food, health, parenting, drugs,
           and employment
           </li>
-          <li>
-            <a>Misgendering</a> someone by deliberately referring to a person
+          <li><a>Misgendering</a> someone by deliberately referring to a person
             using the wrong pronouns or by using someone's proper names or
             other terms that person has asked not to be used, also known as
             <a>deadnaming</a>.
@@ -256,25 +255,24 @@
           </li>
           <li>Threats.
           </li>
-	 <li>Deliberate misinformation.
+	        <li>Deliberate misinformation.
           </li>
           <li>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.
           </li>
           <li>Deliberate intimidation.
           </li>
-	 <li>Personal attacks.
+	        <li>Personal attacks.
           </li>
           <li>Stalking or physically following or invading someone's personal space after a request to stop.</li>
-		<li>Exposing others to contagious disease.</lI>
-
-		<li>
-            <a>Harassing</a> photography or recording, including logging online
+		      <li>Exposing others to contagious disease.</li>
+          <li><a>Harassing</a> photography or recording, including logging online
             activity for <a>harassment</a> purposes.
           </li>
           <li>Sustained disruption of discussion. This may include, but
           is not limited to, various common methods of engaging in bad
-          faith discourse such as:<ul>
+          faith discourse such as:
+            <ul>
               <li><dfn>concern trolling</dfn>: disingenuously
               expressesing concern in order to undermine or derail a
               discussion, <cite><a href=
@@ -426,11 +424,11 @@
           Immediately
         </h3>
         <ul>
-          <li>Pointing out if someone is violating the CEPC to give them the
+          <li>Pointing out if someone is violating the CoC to give them the
           chance to withdraw or edit their statement
           </li>
           <li>Reminding <a>participants</a> that meetings and work operate
-          under the CEPC
+          under the CoC
           </li>
           <li>Asking someone to leave a meeting or a conversation thread
           </li>


### PR DESCRIPTION
I did a quick find and replace of CEPC to CoC to demo the discussion we had in the Feb 14th meeting.

We don't actually mention the name of the document too often within the document itself, which makes this change quite lightweight. 

Comments welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/245.html" title="Last updated on Mar 14, 2023, 4:33 PM UTC (ab18954)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/245/27c19d7...ab18954.html" title="Last updated on Mar 14, 2023, 4:33 PM UTC (ab18954)">Diff</a>