### PR TITLE
Fixing missed "CEPC" mentions and attribution error

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <section id="abstract">
       <p class="ed-note">The wording of this section is under review.</p>
       <p>
-        W3C's <cite>Code of Ethics and Professional Conduct</cite> defines
+        W3C's <cite>Code of Conduct</cite> defines
         expected and unacceptable behaviors and promotes high standards of
         professional practice. The goals of this code are to:
       </p>
@@ -97,7 +97,7 @@
         of the organization.
       </p>
       <p>
-        The CEPC is complemented by a set of <a href=
+        The CoC (or "code") is complemented by a set of <a href=
         "https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a> and applies
         to any member of the W3C community – staff, members, invited experts,
         and <a>participants</a> in W3C meetings, W3C teleconferences, W3C
@@ -112,16 +112,16 @@
       </p>
       <section id="updates">
         <h3>
-          Updates to CEPC
+          Updates to the CoC
         </h3>
         <p>
-          The CEPC is maintained by the Positive Work Environment Community Group. In order to keep the CEPC up to date with the needs and scope of W3C, PWE will routinely review and update the CEPC as needed. 
+          The CoC is maintained by the Positive Work Environment Community Group. In order to keep the CoC up to date with the needs and scope of W3C, PWE will routinely review and update the CoC as needed. 
         </p>
         <p>
-          In March of each year, the CEPC Review Period will open. During this period PWE will work with W3C members, ombudspeople, and the Advisory Board and Advisory Committee to intake and review any issues or recommendations for changes to CEPC. This period of review will last 3 months, and should changes be required, PWE will deliver a new version of the CEPC to the Advisory Board by the end of July.
+          In March of each year, the CoC Review Period will open. During this period PWE will work with W3C members, ombudspeople, and the Advisory Board and Advisory Committee to intake and review any issues or recommendations for changes to CoC. This period of review will last 3 months, and should changes be required, PWE will deliver a new version of the CoC to the Advisory Board by the end of July.
         </p>
         <p>
-          If you have any concerns or issues with CEPC, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a> at any time.
+          If you have any concerns or issues with CoC, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a> at any time.
         </p>
       </section>
     </section>
@@ -760,7 +760,7 @@
         </dt>
         <dd>
           <p>
-            Language or behaviour that may appear kind or helpful but conveys a feeling of superiority or condescension.
+            Language or behaviour that may appear kind or helpful but conveys a feeling of superiority or condescension. <cite><a href="https://languages.oup.com/">Adapted from the Oxford Languages Dictionary.</a></cite>
           </p>
         </dd>
         <dt>


### PR DESCRIPTION
Recent merges accidentally added "CEPC" back into the document, I have fixed that. 

Also added the missing attribution for "patronizing" as mentioned in issue #264.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/288.html" title="Last updated on May 10, 2023, 5:55 PM UTC (fb2b19a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/288/12146bd...fb2b19a.html" title="Last updated on May 10, 2023, 5:55 PM UTC (fb2b19a)">Diff</a>