### PR TITLE
Adding "well, actually" back as an example

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,8 @@
               </li>
               <li>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
-              <li>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g. interjections like "Well, actually..." or "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
+              <li>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g. "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
+              <li>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
             </ul>
           </li>
           <li>Microaggressions, which are small comments or questions, either

--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
               </li>
               <li>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
-              <li>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g. "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
+              <li>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g. interjections like "Well, actually..." or "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
             </ul>
           </li>
           <li>Microaggressions, which are small comments or questions, either


### PR DESCRIPTION
By popular request, everyone's favourite example of patronizing language.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/300.html" title="Last updated on Jun 23, 2023, 3:34 PM UTC (90ddbce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/300/acaadd9...90ddbce.html" title="Last updated on Jun 23, 2023, 3:34 PM UTC (90ddbce)">Diff</a>