### PR TITLE
Fixing ReSpec issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,11 @@
         company: "Samsung",
         companyURL: "https://samsung.com",
         w3cid: 66378
+      }, {
+        name: "Wendy Reid",
+        company: "Rakuten Kobo",
+        companyURL: "https://rakuten.com",
+        w3cid: 102009
       }],
       github: {
         repoURL: "https://github.com/w3c/PWETF/",
@@ -129,7 +134,7 @@
         Statement of Intent
       </h2>
       <p>
-        W3C is committed to maintaining a <strong>positive</strong> work environment for all, including and especially those from historically marginalized communities. This commitment calls for a workplace where
+        W3C is committed to maintaining a <strong>positive</strong> work environment for all, including and especially those from historically <a>marginalized communities</a>. This commitment calls for a workplace where
         <a>participants</a> at all levels behave according to the rules of the
         following code. A foundational concept of this code is that <em>we all
         share responsibility</em> for our work environment.
@@ -180,7 +185,7 @@
           <li>Do not accept or engage in abusive behavior in any form, whether it is
         verbal, physical, sexual, or implied.</li>
           <li>Be honest. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid, straightforward, and frank.</li>
-          <li>Be inclusive and promote <a>diversity</a>. Seek diverse
+          <li>Be <a>inclusive</a> and promote <a>diversity</a>. Seek diverse
           perspectives. Diversity of views and of people powers innovation,
           even if it is not always comfortable. Encourage all voices. Help new
           perspectives be heard and listen actively. 
@@ -194,9 +199,9 @@
           relationships. For some cultures, overtly friendly disposition
           towards another participant involving body contact (e.g.: hugging,
           touching on the arm or shoulder, or kissing) is uncommon and may be
-          perceived as an invasion of personal space, or as unwelcome advances.
+          perceived as an invasion of personal space, or as <a>unwelcome advances</a>.
           </li>
-          <li>Work to eliminate your own biases, prejudices, and discriminatory
+          <li>Work to eliminate your own biases, <a>prejudices</a>, and discriminatory
           practices.
           </li>
           <li>Think of others’ needs from their point of view. Use preferred
@@ -245,7 +250,7 @@
           <a>Unacceptable behaviors</a> include, but are not limited to:
         </p>
         <ol>
-          <li>Offensive comments related to socio-economic status, sexual orientation, religion, race, physical appearance, neurotype, nationality, mental health, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age
+          <li>Offensive comments related to <a>socio-economic status</a>, <a>sexual orientation</a>, religion, race, physical appearance, <a>neurotype</a>, nationality, <a>mental health</a>, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age
           </li>
           <li>Unwelcome comments regarding a person’s lifestyle choices and
           practices, including those related to food, health, parenting, drugs,
@@ -283,26 +288,26 @@
           is not limited to, various common methods of engaging in bad
           faith discourse such as:
             <ul>
-              <li><dfn>concern trolling</dfn>: disingenuously
+              <li><dfn class="lint-ignore">concern trolling</dfn>: disingenuously
               expressesing concern in order to undermine or derail a
               discussion, <cite><a href=
               "https://geekfeminism.wikia.org/wiki/Concern_troll">Geek
               Feminism Wiki</a></cite>
               </li>
-              <li><dfn>sealioning</dfn>: asking numerous questions about
+              <li><dfn class="lint-ignore">sealioning</dfn>: asking numerous questions about
               basic concepts in an attempt to derail discussion, to
               stifle participation, or to provoke a critical response in
               order to appear a victim, <cite><a href=
               "https://rationalwiki.org/wiki/Just_asking_questions#Sealioning">
               RationalWiki</a></cite>
               </li>
-              <li><dfn>Gish Galloping</dfn>: overwhelming a debate with
+              <li><dfn class="lint-ignore">Gish Galloping</dfn>: overwhelming a debate with
               many weak arguments in an attempt to cause others to waste
               time refuting them,
               <cite><a href="https://rationalwiki.org/wiki/Gish_Gallop"
               >RationalWiki</a></cite>
               </li>
-              <li><dfn lang=la>argumentum ad nauseam</dfn>: repeatedly
+              <li><dfn class="lint-ignore" lang="la">argumentum ad nauseam</dfn>: repeatedly
               making claims already shown to be false. <cite><a
               href="https://rationalwiki.org/wiki/Argumentum_ad_nauseam"
               >RationalWiki</a></cite>
@@ -313,7 +318,7 @@
               </li>
             </ul>
           </li>
-          <li>Unwelcome sexual attention.
+          <li><a>Unwelcome sexual attention</a>.
           </li>
           <li>Patterns of inappropriate social contact, such as
           requesting/assuming inappropriate levels of intimacy with others.
@@ -339,7 +344,7 @@
               <li>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
             </ul>
           </li>
-          <li>Microaggressions, which are small comments or questions, either
+          <li><a>Microaggressions</a>, which are small comments or questions, either
           intentional or unintentional, that marginalize people by
           communicating hostile, derogatory, or negative beliefs. Examples
           include:
@@ -371,7 +376,7 @@
           </li>
           <li>Communication in a tone you don’t find congenial.
           </li>
-          <li>Criticisms of racist, sexist, cissexist, or otherwise oppressive behavior or assumptions. Similarly, we will not accept claims of "Reverse" -isms, including "reverse racism," "reverse sexism," and "cisphobia".
+          <li>Criticisms of <a>racist</a>, <a>sexist</a>, <a>cissexist</a>, or otherwise oppressive behavior or assumptions. Similarly, we will not accept claims of "Reverse" -isms, including "reverse racism," "reverse sexism," and "cisphobia".
           </li>
  </ul>
       </section>
@@ -634,7 +639,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>Inclusivity</dfn>
+          <dfn data-lt="inclusive">Inclusivity</dfn>
         </dt>
         <dd>
           <p>
@@ -643,7 +648,7 @@
           </p>
         </dd>
         <dt>
-          <dfn data-lt="insulting|insult">Insulting behavior</dfn>
+          <dfn class="lint-ignore" data-lt="insulting|insult">Insulting behavior</dfn>
         </dt>
         <dd>
           <p>
@@ -680,7 +685,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>Microagression</dfn>
+          <dfn data-lt="Microaggressions">Microagression</dfn>
         </dt>
         <dd>
           <p>
@@ -756,7 +761,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>Prejudice</dfn>
+          <dfn data-lt="prejudices|prejudicial">Prejudice</dfn>
         </dt>
         <dd>
           <p>
@@ -764,7 +769,7 @@
           </p>
         </dd>
         <dt>
-          <dfn>Racism</dfn>
+          <dfn data-lt="racist">Racism</dfn>
         </dt>
         <dd>
           <p>
@@ -774,7 +779,7 @@
           </p>
         </dd>
                 <dt>
-          <dfn>Sexism</dfn>
+          <dfn data-lt="sexist">Sexism</dfn>
         </dt>
         <dd>
           <p>
@@ -787,7 +792,7 @@
           </p>
         </dd>
         <dt>
-          <dfn data-lt="sexually harass">Sexual harassment</dfn>
+          <dfn class="lint-ignore" data-lt="sexually harass">Sexual harassment</dfn>
         </dt>
         <dd><p>Includes requests for sexual favors, and other verbal or physical
           conduct of a sexual nature, where:</p>
@@ -832,10 +837,14 @@
           </p>
         </dd>
         <dt>
-          <dfn>Unwelcome sexual advance</dfn>
+          <dfn data-lt="unwelcome sexual attention|unwelcome advances">Unwelcome sexual advance</dfn>
         </dt>
-      <dd><p>includes visual displays of degrading sexual images, sexually suggestive conduct, offensive remarks of a sexual nature, requests for sexual favors, unwelcome physical contact, and sexual assault.</p></dd>
-    </dl>
+        <dd>
+          <p>
+            Includes visual displays of degrading sexual images, sexually suggestive conduct, offensive remarks of a sexual nature, requests for sexual favors, unwelcome physical contact, and sexual assault.
+          </p>
+        </dd>
+      </dl>
     </section>
     <section id="Attribution">
       <h2>


### PR DESCRIPTION
Covered the ReSpec errors relating to definitions. 

There is one remaining error about "group", however fixing it results in the document being formatted as a CG report, which does not fit it's role. Leaving as is for now. 

Added myself in as editor after forgetting to do so for the last few months!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/301.html" title="Last updated on Jun 27, 2023, 9:23 PM UTC (82effc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/301/8873562...82effc2.html" title="Last updated on Jun 27, 2023, 9:23 PM UTC (82effc2)">Diff</a>