### PR TITLE
Editorial in CoC

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
           </li>
 		      <li>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
           <li>Be sensitive to language differences. English is the default
-          language of the W3C. However, only some of us are native English
+          language of W3C. However, only some of us are native English
           speakers. Many <a>participants</a> speak English as a second (or
           third) language. People who communicate in non-native language often
           struggle to understand fast and/or quiet speech and may speak louder
@@ -406,7 +406,7 @@
         complaints will be taken seriously and will receive a response.
       </p>
       <p>
-        If you are responsible for a community within the W3C such as in the
+        If you are responsible for a community within W3C such as in the
         role of a chair of a working group and you witness <a>harassment</a> or
         any other behavior which goes against this code you are encouraged to
         address the issue directly. If you need assistance, you might get
@@ -511,7 +511,7 @@
         </dt>
         <dd>
           <p>
-            Within the W3C, this is behavior which abides by this Code of
+            Within W3C, this is behavior which abides by this Code of
             Conduct.
           </p>
         </dd>
@@ -720,8 +720,8 @@
           <p>
             One who assists individuals and groups in the resolution of
             conflicts or concerns. They are a designated neutral who is
-            appointed or employed by the W3C to facilitate the informal
-            resolution of concerns of <a>participants</a> within the W3C.
+            appointed or employed by W3C to facilitate the informal
+            resolution of concerns of <a>participants</a> within W3C.
           </p>
         </dd>
         <dt>


### PR DESCRIPTION
When using the acronym "W3C", we treat it as a proper noun so no "the" prepended, unless it's used as an adjective (e.g., "The W3C Team is small but mighty.") cf. https://www.w3.org/about/press-media/#w3c-brand


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/352.html" title="Last updated on Oct 12, 2023, 4:00 PM UTC (65d6ecc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/352/cee2681...65d6ecc.html" title="Last updated on Oct 12, 2023, 4:00 PM UTC (65d6ecc)">Diff</a>