### PR TITLE
Editorial change to sustained disruption

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
               href="https://rationalwiki.org/wiki/Argumentum_ad_nauseam"
               >RationalWiki</a></cite>
               </li>
-              <li>Continuing to raise issues that were not accepted by the group consensus. It you feel you have important new information or that your argument did not get a fair hearing, then contact the chairs. Otherwise, accept the group consensus and move on.
+              <li>Continuing to raise issues that bring no new information when a group decision has already been made. If you feel that your argument did not get a fair hearing, or if the outcome is otherwise unacceptable to you, contact the chairs, or follow proper escalation paths. Otherwise, accept the decision and move on. (See also <a href="https://www.w3.org/Consortium/Process/#managing-dissent">“Process &sect;5.2.2 Managing Dissent”</a>.)
               </li>
               <li>Repeatedly interrupting or talking over someone else.
               </li>


### PR DESCRIPTION
Based on AB feedback, made a clarifying change to the bullet on continuing to raise issues, added an informative reference to the process section on managing dissent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/357.html" title="Last updated on Oct 24, 2023, 2:57 PM UTC (f78681b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/357/8d5b46b...f78681b.html" title="Last updated on Oct 24, 2023, 2:57 PM UTC (f78681b)">Diff</a>