### PR TITLE
Give ids to all entries in the behavior lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@
           <li id=setting-boundaries>Reasonable communication of boundaries, such as “leave me alone,”
           “go away,” or “I’m not discussing this with you”.
           </li>
-          <li id=congenial>Communication in a tone you don’t find congenial.
+          <li id=non-congenial-tone>Communication in a tone you don’t find congenial.
           </li>
           <li id=criticism>Critizing oppressive behavior or assumptions, such as those that are <a>racist</a>, <a>sexist</a>, or <a>cissexist</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
             other terms that person has asked not to be used, also known as
             <a>deadnaming</a>.
           </li>
-          <li id=sexual-images>Gratuitous or off-topic sexual images or behavior in spaces where
+          <li id=inappropriate-images-behavior>Gratuitous or off-topic sexual images or behavior in spaces where
           they are not appropriate.
           </li>
           <li id=non-consensual-contact>Physical contact and simulated physical contact (e.g., textual

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
               <li id=feigning-surprise>Feigning surprise at someone’s lack of knowledge or awareness
               about a topic.
               </li>
-              <li id=charged>The use of racially charged language to describe an
+              <li id=racist-language>The use of racially charged language to describe an
               individual or thing.
               </li>
               <li id=demeans>Referring to an individual in a way that <a>demeans</a> or

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
             <ul>
               <li id=assumptions>Intentionally or unintentionally making assumptions about the skills or knowledge of others, such as using language that implies the audience is uninformed on a topic (e.g., interjections like "I can't believe you don't know about [topic]").
               </li>
-              <li id=grandmother>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
+              <li id=assuming-unskilled>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
               <li id=unnecessary>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
               <li id=actually>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
               <li id=assuming-unskilled>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
               <li id=unnecessary-comments>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
-              <li id=actually>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
+              <li id=well-actually>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
             </ul>
           </li>
           <li id=microagression><a>Microaggressions</a>, which are small comments or questions, either

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
           </li>
           <li id=misinfo>Deliberate misinformation.
           </li>
-          <li id=violence>Incitement of violence towards any individual, including
+          <li id=incitement>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.
           </li>
           <li id=intimidation>Deliberate intimidation.

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
           </li>
           <li id=stop>Continued one-on-one communication after request to stop.
           </li>
-          <li id=outing>Deliberate outing of any aspect of a person’s <a>gender
+          <li id=gender-outing>Deliberate outing of any aspect of a person’s <a>gender
           identity</a> without their <a>consent</a>.
           </li>
           <li id=publication>Publication of non-harassing private communication without

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
         <ol>
           <li id=offensive>Offensive comments related to <a>socio-economic status</a>, <a>sexual orientation</a>, religion, race, physical appearance, <a>neurotype</a>, nationality, <a>mental health</a>, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age.
           </li>
-          <li id=unwelcome>Unwelcome comments regarding a person’s lifestyle choices and
+          <li id=lifestyle-comments>Unwelcome comments regarding a person’s lifestyle choices and
           practices, including those related to food, health, parenting, drugs,
           and employment.
           </li>

--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
               </li>
               <li id=assuming-unskilled>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
-              <li id=unnecessary>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
+              <li id=unnecessary-comments>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
               <li id=actually>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
             </ul>
           </li>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
           liberal in what you accept from others and acknowledge the
           contributions of your peers.
           </li>
-          <li id=accomodate>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
+          <li id=accommodate>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
           <li id=sensitive>Be sensitive to language differences. English is the default
           language of W3C. However, only some of us are native English
           speakers. Many <a>participants</a> speak English as a second (or

--- a/index.html
+++ b/index.html
@@ -152,14 +152,14 @@
           and strengths, including in situations of high pressure and urgency.
         </p>
         <ol>
-          <li>Appreciate and accommodate our similarities and differences. We
+          <li id=appreciate>Appreciate and accommodate our similarities and differences. We
           come from many cultures and backgrounds, ways of life, and standards
           of behavior. Cultural differences can encompass everything from
           official religious observances to personal habits to clothing. Be
           respectful of people with different practices, attitudes, and
           beliefs.
           </li>
-          <li>Have empathy when discussing sensitive issues. Some participants
+          <li id=empathy>Have empathy when discussing sensitive issues. Some participants
           may have experienced (or been subjected to) various forms of violence
           in their lives, which may cause distress when they are reminded of
           it. Avoid making jokes or callously mentioning sexual violence such
@@ -169,7 +169,7 @@
           sure that <a>participants</a> are appropriately warned in advance so
           they can choose to step out of these discussions.
           </li>
-          <li>Treat everyone with respect. We are a large community of people who are passionate
+          <li id=respect>Treat everyone with respect. We are a large community of people who are passionate
           about our work, sometimes holding strong opinions and beliefs. We are
           committed to dealing with each other with courtesy, respect, and
           dignity at all times. Misunderstandings and disagreements do happen.
@@ -177,36 +177,36 @@
           that courtesy, respect, and dignity, even when emotions are
           heightened.
           </li>
-          <li>Do not accept or engage in abusive behavior in any form, whether it is
+          <li id=no-abuse>Do not accept or engage in abusive behavior in any form, whether it is
         verbal, physical, sexual, or implied.</li>
-          <li>Be honest. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid, straightforward, and frank.</li>
-          <li>Be <a>inclusive</a> and promote <a>diversity</a>. Seek diverse
+          <li id=honest>Be honest. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid, straightforward, and frank.</li>
+          <li id=promote>Be <a>inclusive</a> and promote <a>diversity</a>. Seek diverse
           perspectives. Diversity of views and of people powers innovation,
           even if it is not always comfortable. Encourage all voices. Help new
           perspectives be heard and listen actively.
           </li>
-          <li>Be aware of how much time is taken up by dominant members of the
+          <li id=dominant>Be aware of how much time is taken up by dominant members of the
           group. If you find yourself dominating a discussion, it is especially important to step back and
           encourage other voices to join in. Provide alternative ways to
           contribute.
           </li>
-          <li>Be aware that displays of affection may complicate professional
+          <li id=affection>Be aware that displays of affection may complicate professional
           relationships. For some people, overtly friendly disposition
           towards another participant involving body contact (e.g., hugging,
           touching on the arm or shoulder, or kissing) can be, or be 
           an invasion of personal space, or perceived as an <a>unwelcome advance</a>.
           </li>
-          <li>Work to eliminate your own biases, <a>prejudices</a>, and discriminatory
+          <li id=biases>Work to eliminate your own biases, <a>prejudices</a>, and discriminatory
           practices.
           </li>
-          <li>Think of others’ needs from their point of view. Use preferred
+          <li id=pov>Think of others’ needs from their point of view. Use preferred
           names, titles (including pronouns), and the appropriate tone of
           voice. Therefore, be formal and conservative in what you do and
           liberal in what you accept from others and acknowledge the
           contributions of your peers.
           </li>
-		      <li>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
-          <li>Be sensitive to language differences. English is the default
+          <li id=accomodate>Accommodate participants' needs for physical distancing and other accommodations or precautions due to health concerns such as immune deficiency, allergies, or chemical sensitivity.</li>
+          <li id=sensitive>Be sensitive to language differences. English is the default
           language of W3C. However, only some of us are native English
           speakers. Many <a>participants</a> speak English as a second (or
           third) language. People who communicate in non-native language often
@@ -215,7 +215,7 @@
           someone struggles to express their thoughts, help ensure their ideas
           are adequately expressed, heard, and granted thorough consideration.
           </li>
-          <li>Respect confidentiality and privacy. Sometimes, matters we discuss may
+          <li id=priv-conf>Respect confidentiality and privacy. Sometimes, matters we discuss may
           fall under various <a href=
           "https://www.w3.org/Consortium/Process/#confidentiality-levels">confidentiality</a>
           agreements and strict adherence to these agreements is expected. In
@@ -245,119 +245,119 @@
           <a>Unacceptable behaviors</a> include, but are not limited to:
         </p>
         <ol>
-          <li>Offensive comments related to <a>socio-economic status</a>, <a>sexual orientation</a>, religion, race, physical appearance, <a>neurotype</a>, nationality, <a>mental health</a>, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age.
+          <li id=offensive>Offensive comments related to <a>socio-economic status</a>, <a>sexual orientation</a>, religion, race, physical appearance, <a>neurotype</a>, nationality, <a>mental health</a>, language, indigeneity, immigration status, gender, <a>gender identity</a> and <a>gender expression</a>, ethnicity, disability (both visible and invisible), caste, body, or age.
           </li>
-          <li>Unwelcome comments regarding a person’s lifestyle choices and
+          <li id=unwelcome>Unwelcome comments regarding a person’s lifestyle choices and
           practices, including those related to food, health, parenting, drugs,
           and employment.
           </li>
-          <li><a>Misgendering</a> someone by deliberately referring to a person
+          <li id=misgendering><a>Misgendering</a> someone by deliberately referring to a person
             using the wrong pronouns or by using someone's proper names or
             other terms that person has asked not to be used, also known as
             <a>deadnaming</a>.
           </li>
-          <li>Gratuitous or off-topic sexual images or behavior in spaces where
+          <li id=gratuitous>Gratuitous or off-topic sexual images or behavior in spaces where
           they are not appropriate.
           </li>
-          <li>Physical contact and simulated physical contact (e.g., textual
+          <li id=contact>Physical contact and simulated physical contact (e.g., textual
           descriptions like “hug” or “backrub”) without <a>consent</a> or after
           a request to stop.
           </li>
-          <li>Threats.
+          <li id=threat>Threats.
           </li>
-	        <li>Deliberate misinformation.
+          <li id=misinfo>Deliberate misinformation.
           </li>
-          <li>Incitement of violence towards any individual, including
+          <li id=violence>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.
           </li>
-          <li>Deliberate intimidation.
+          <li id=intimidation>Deliberate intimidation.
           </li>
-	        <li>Personal attacks.
+          <li id=attacks>Personal attacks.
           </li>
-          <li>Stalking or physically following or invading someone's personal space after a request to stop.</li>
-		      <li>Exposing others to contagious disease.</li>
-          <li><a>Harassing</a> photography or recording, including logging online
+          <li id=stalking>Stalking or physically following or invading someone's personal space after a request to stop.</li>
+          <li id=disease>Exposing others to contagious disease.</li>
+          <li id=photo><a>Harassing</a> photography or recording, including logging online
             activity for <a>harassment</a> purposes.
           </li>
-          <li>Sustained disruption of discussion. This may include, but
+          <li id=disruption>Sustained disruption of discussion. This may include, but
           is not limited to, various common methods of engaging in bad
           faith discourse such as:
             <ul>
-              <li><dfn class="lint-ignore">concern trolling</dfn>: disingenuously
+              <li id=concern-trolling><dfn class="lint-ignore">concern trolling</dfn>: disingenuously
               expressing concern in order to undermine or derail a
               discussion. <cite><a href=
               "https://geekfeminism.wikia.org/wiki/Concern_troll">Geek
               Feminism Wiki</a></cite>
               </li>
-              <li><dfn class="lint-ignore">sealioning</dfn>: asking numerous questions about
+              <li id=sealioning><dfn class="lint-ignore">sealioning</dfn>: asking numerous questions about
               basic concepts in an attempt to derail discussion, to
               stifle participation, or to provoke a critical response in
               order to appear a victim. <cite><a href=
               "https://rationalwiki.org/wiki/Just_asking_questions#Sealioning">
               RationalWiki</a></cite>
               </li>
-              <li><dfn class="lint-ignore">Gish Galloping</dfn>: overwhelming a debate with
+              <li id=gish-galloping><dfn class="lint-ignore">Gish Galloping</dfn>: overwhelming a debate with
               many weak arguments in an attempt to cause others to waste
               time refuting them.
               <cite><a href="https://rationalwiki.org/wiki/Gish_Gallop"
               >RationalWiki</a></cite>
               </li>
-              <li><dfn class="lint-ignore" lang="la">argumentum ad nauseam</dfn>: repeatedly
+              <li id=ad-nauseam><dfn class="lint-ignore" lang="la">argumentum ad nauseam</dfn>: repeatedly
               making claims already shown to be false. <cite><a
               href="https://rationalwiki.org/wiki/Argumentum_ad_nauseam"
               >RationalWiki</a></cite>
               </li>
-              <li>Continuing to raise issues that bring no new information when a group decision has already been made. If you feel that your argument did not get a fair hearing, or if the outcome is otherwise unacceptable to you, contact the chairs, or follow proper escalation paths. Otherwise, accept the decision and move on. (See also <a href="https://www.w3.org/Consortium/Process/#managing-dissent">“Process &sect;5.2.2 Managing Dissent”</a>.)
+              <li id=no-new-info>Continuing to raise issues that bring no new information when a group decision has already been made. If you feel that your argument did not get a fair hearing, or if the outcome is otherwise unacceptable to you, contact the chairs, or follow proper escalation paths. Otherwise, accept the decision and move on. (See also <a href="https://www.w3.org/Consortium/Process/#managing-dissent">“Process &sect;5.2.2 Managing Dissent”</a>.)
               </li>
-              <li>Repeatedly interrupting or talking over someone else.
+              <li id=interrupt>Repeatedly interrupting or talking over someone else.
               </li>
             </ul>
           </li>
-          <li><a>Unwelcome sexual attention</a>.
+          <li id=sexual><a>Unwelcome sexual attention</a>.
           </li>
-          <li>Patterns of inappropriate social contact, such as
+          <li id=inappropriate>Patterns of inappropriate social contact, such as
           requesting/assuming inappropriate levels of intimacy with others.
           </li>
-          <li>Continued one-on-one communication after request to stop.
+          <li id=stop>Continued one-on-one communication after request to stop.
           </li>
-          <li>Deliberate outing of any aspect of a person’s <a>gender
+          <li id=outing>Deliberate outing of any aspect of a person’s <a>gender
           identity</a> without their <a>consent</a>.
           </li>
-          <li>Publication of non-harassing private communication without
+          <li id=publication>Publication of non-harassing private communication without
           <a>consent</a> by the involved parties.
           </li>
-          <li>Use of coded language (also known as "dog whistles") used to
+          <li id=dog-whistles>Use of coded language (also known as "dog whistles") used to
           rally support for hate groups or to intimidate vulnerable groups.
           </li>
-          <li><a>Patronizing</a> language or behavior:
+          <li id=patronizing><a>Patronizing</a> language or behavior:
             <ul>
-              <li>Intentionally or unintentionally making assumptions about the skills or knowledge of others, such as using language that implies the audience is uninformed on a topic (e.g., interjections like "I can't believe you don't know about [topic]").
+              <li id=assumptions>Intentionally or unintentionally making assumptions about the skills or knowledge of others, such as using language that implies the audience is uninformed on a topic (e.g., interjections like "I can't believe you don't know about [topic]").
               </li>
-              <li>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
+              <li id=grandmother>Assuming that particular groups of people are technically unskilled due to their characteristics (e.g., “So easy your grandmother could do it”, which implies an older woman might not be technically competent).
               </li>
-              <li>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
-              <li>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
+              <li id=unnecessary>Interrupting or repeatedly commenting in conversations with unneccessary clarifications or comments on audience behaviour (e.g., "I don't think you understood my previous comment...", grammar or language corrections that were not invited).</li>
+              <li id=actually>Regardless of the speaker's intentions, some phrases or constructions lead people to expect a patronizing statement to follow. For example, beginning an interjection with a phrase like "Well, actually..." can set this expectation and be taken as a sign of disrespect.</li>
             </ul>
           </li>
-          <li><a>Microaggressions</a>, which are small comments or questions, either
+          <li id=microagression><a>Microaggressions</a>, which are small comments or questions, either
           intentional or unintentional, that marginalize people by
           communicating hostile, derogatory, or negative beliefs. Examples
           include:
             <ul>
-              <li>Feigning surprise at someone’s lack of knowledge or awareness
+              <li id=surprise>Feigning surprise at someone’s lack of knowledge or awareness
               about a topic.
               </li>
-              <li>The use of racially charged language to describe an
+              <li id=charged>The use of racially charged language to describe an
               individual or thing.
               </li>
-              <li>Referring to an individual in a way that <a>demeans</a> or
+              <li id=demeans>Referring to an individual in a way that <a>demeans</a> or
               challenges the validity of any part of their identity.
               </li>
-              <li>Mocking someone’s real or perceived accent or first language.
+              <li id=mocking>Mocking someone’s real or perceived accent or first language.
               </li>
             </ul>
           </li>
-          <li>Retaliating, or taking adverse action, against anyone who files a complaint that someone has
+          <li id=retaliation>Retaliating, or taking adverse action, against anyone who files a complaint that someone has
           violated this code of conduct.
           </li>
         </ol>
@@ -366,12 +366,12 @@
 	<h3>Safety versus Comfort</h3>
         <p>This Code prioritizes the safety of individuals, particularly those in marginalized communities, over the comfort of others. For example, the following behaviors are presumed to be acceptable even if they make some participants uncomfortable:</p>
         <ul>
-          <li>Reasonable communication of boundaries, such as “leave me alone,”
+          <li id=boundaries>Reasonable communication of boundaries, such as “leave me alone,”
           “go away,” or “I’m not discussing this with you”.
           </li>
-          <li>Communication in a tone you don’t find congenial.
+          <li id=congenial>Communication in a tone you don’t find congenial.
           </li>
-          <li>Critizing oppressive behavior or assumptions, such as those that are <a>racist</a>, <a>sexist</a>, or <a>cissexist</a>.
+          <li id=criticism>Critizing oppressive behavior or assumptions, such as those that are <a>racist</a>, <a>sexist</a>, or <a>cissexist</a>.
           </li>
         </ul>
         <p>Note that claims of perceived "reverse"-isms including "reverse racism," "reverse sexism," and "cisphobia" are not acceptable.</p>

--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
           </li>
           <li id=non-congenial-tone>Communication in a tone you don’t find congenial.
           </li>
-          <li id=criticism>Critizing oppressive behavior or assumptions, such as those that are <a>racist</a>, <a>sexist</a>, or <a>cissexist</a>.
+          <li id=criticizing-oppression>Critizing oppressive behavior or assumptions, such as those that are <a>racist</a>, <a>sexist</a>, or <a>cissexist</a>.
           </li>
         </ul>
         <p>Note that claims of perceived "reverse"-isms including "reverse racism," "reverse sexism," and "cisphobia" are not acceptable.</p>

--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
           <li id=gender-outing>Deliberate outing of any aspect of a person’s <a>gender
           identity</a> without their <a>consent</a>.
           </li>
-          <li id=publication>Publication of non-harassing private communication without
+          <li id=publishing-private-comm>Publication of non-harassing private communication without
           <a>consent</a> by the involved parties.
           </li>
           <li id=dog-whistles>Use of coded language (also known as "dog whistles") used to

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
               </li>
             </ul>
           </li>
-          <li id=sexual><a>Unwelcome sexual attention</a>.
+          <li id=sexual-attention><a>Unwelcome sexual attention</a>.
           </li>
           <li id=inappropriate>Patterns of inappropriate social contact, such as
           requesting/assuming inappropriate levels of intimacy with others.

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
           communicating hostile, derogatory, or negative beliefs. Examples
           include:
             <ul>
-              <li id=surprise>Feigning surprise at someone’s lack of knowledge or awareness
+              <li id=feigning-surprise>Feigning surprise at someone’s lack of knowledge or awareness
               about a topic.
               </li>
               <li id=charged>The use of racially charged language to describe an

--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@
           </li>
           <li id=intimidation>Deliberate intimidation.
           </li>
-          <li id=attacks>Personal attacks.
+          <li id=personal-attacks>Personal attacks.
           </li>
           <li id=stalking>Stalking or physically following or invading someone's personal space after a request to stop.</li>
           <li id=disease>Exposing others to contagious disease.</li>

--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
           </li>
           <li id=sexual-attention><a>Unwelcome sexual attention</a>.
           </li>
-          <li id=inappropriate>Patterns of inappropriate social contact, such as
+          <li id=inappropriate-contact>Patterns of inappropriate social contact, such as
           requesting/assuming inappropriate levels of intimacy with others.
           </li>
           <li id=stop>Continued one-on-one communication after request to stop.

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
           <li id=no-abuse>Do not accept or engage in abusive behavior in any form, whether it is
         verbal, physical, sexual, or implied.</li>
           <li id=honest>Be honest. Be truthful, sincere, forthright and, unless professional duties require confidentiality or special discretion, candid, straightforward, and frank.</li>
-          <li id=promote>Be <a>inclusive</a> and promote <a>diversity</a>. Seek diverse
+          <li id=promote-diversity>Be <a>inclusive</a> and promote <a>diversity</a>. Seek diverse
           perspectives. Diversity of views and of people powers innovation,
           even if it is not always comfortable. Encourage all voices. Help new
           perspectives be heard and listen actively.

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
           touching on the arm or shoulder, or kissing) can be, or be 
           an invasion of personal space, or perceived as an <a>unwelcome advance</a>.
           </li>
-          <li id=biases>Work to eliminate your own biases, <a>prejudices</a>, and discriminatory
+          <li id=eliminate-bias>Work to eliminate your own biases, <a>prejudices</a>, and discriminatory
           practices.
           </li>
           <li id=pov>Think of others’ needs from their point of view. Use preferred

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
             other terms that person has asked not to be used, also known as
             <a>deadnaming</a>.
           </li>
-          <li id=gratuitous>Gratuitous or off-topic sexual images or behavior in spaces where
+          <li id=sexual-images>Gratuitous or off-topic sexual images or behavior in spaces where
           they are not appropriate.
           </li>
           <li id=contact>Physical contact and simulated physical contact (e.g., textual

--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@
               <li id=racist-language>The use of racially charged language to describe an
               individual or thing.
               </li>
-              <li id=demeans>Referring to an individual in a way that <a>demeans</a> or
+              <li id=demeaning>Referring to an individual in a way that <a>demeans</a> or
               challenges the validity of any part of their identity.
               </li>
               <li id=mocking>Mocking someone’s real or perceived accent or first language.

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
           <li id=sexual-images>Gratuitous or off-topic sexual images or behavior in spaces where
           they are not appropriate.
           </li>
-          <li id=contact>Physical contact and simulated physical contact (e.g., textual
+          <li id=non-consensual-contact>Physical contact and simulated physical contact (e.g., textual
           descriptions like “hug” or “backrub”) without <a>consent</a> or after
           a request to stop.
           </li>

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
           even if it is not always comfortable. Encourage all voices. Help new
           perspectives be heard and listen actively.
           </li>
-          <li id=dominant>Be aware of how much time is taken up by dominant members of the
+          <li id=dominating>Be aware of how much time is taken up by dominant members of the
           group. If you find yourself dominating a discussion, it is especially important to step back and
           encourage other voices to join in. Provide alternative ways to
           contribute.

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
 	<h3>Safety versus Comfort</h3>
         <p>This Code prioritizes the safety of individuals, particularly those in marginalized communities, over the comfort of others. For example, the following behaviors are presumed to be acceptable even if they make some participants uncomfortable:</p>
         <ul>
-          <li id=boundaries>Reasonable communication of boundaries, such as “leave me alone,”
+          <li id=setting-boundaries>Reasonable communication of boundaries, such as “leave me alone,”
           “go away,” or “I’m not discussing this with you”.
           </li>
           <li id=congenial>Communication in a tone you don’t find congenial.


### PR DESCRIPTION
This enables linking directly to a specific entry, to make it easier to reference individual entries

This does not change any of the wording in any part of the document ([class 1 change](https://www.w3.org/Consortium/Process/#class-1), in Process terminology)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/PWETF/pull/366.html" title="Last updated on Jan 31, 2024, 2:15 PM UTC (049f690)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/366/f4efc9e...frivoal:049f690.html" title="Last updated on Jan 31, 2024, 2:15 PM UTC (049f690)">Diff</a>