### PR TITLE
The code of conduct is expected to be hosted under /policies/

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,15 @@
     <script class='remove'>
     // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
     var respecConfig = {
-      edDraftURI: "https://w3c.github.io/PWETF/",
-      latestVersion: "https://www.w3.org/Consortium/cepc/",
-      specStatus: "ED",
+      edDraftURI: "https://www.w3.org/policies/code-of-conduct/drafts/",
+      latestVersion: "https://www.w3.org/policies/code-of-conduct/",
+      specStatus: "base",
       otherLinks: [
         {
         key: "Current Operative Version",
 	      data: [
 	        { value: "",
-	          href: "http://www.w3.org/Consortium/cepc" }
+	          href: "http://www.w3.org/policies/code-of-conduct/" }
         ] }
     	],
       shortName: "pwe",
@@ -74,7 +74,7 @@
       <p>
         This is an editors' draft; a Work in Progress which will be submitted to W3C
 	as a proposed update to the currently operational version of the
-	<a href="https://www.w3.org/Consortium/cepc/">Code of Conduct</a>.
+	<a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
       </p>
       <section id="updates">
         <h3>
@@ -113,7 +113,7 @@
       </p>
       <p>
         The CoC (or "code") is complemented by a set of <a href=
-        "https://www.w3.org/Consortium/pwe/#Procedures">Procedures</a> and applies
+        "https://www.w3.org/about/positive-work-environment/#Procedures">Procedures</a> and applies
         to any member of the W3C community – staff, members, invited experts,
         and <a>participants</a> in W3C meetings, W3C teleconferences, W3C
         mailing lists, code repositories, W3C conferences or W3C functions, etc.
@@ -121,9 +121,9 @@
         obligations pertaining to any particular situation.
       </p>
       <p>
-        <a href="https://www.w3.org/Consortium/pwe/#Education">Education and training
+        <a href="https://www.w3.org/about/positive-work-environment/#Education">Education and training
         materials</a> are available from the <a href=
-        "https://www.w3.org/Consortium/pwe/">Positive Work Environment public homepage</a>.
+        "https://www.w3.org/about/positive-work-environment/">Positive Work Environment public homepage</a>.
       </p>
     </section>
     <section>
@@ -402,7 +402,7 @@
       </p>
       <p>
 	You are welcome to raise issues directly with the <a>Ombudspeople</a> as a <a href=
-        "mailto:ombuds@w3.org">group</a> or <a href="https://www.w3.org/Consortium/pwe/#Procedures">individually</a>. All
+        "mailto:ombuds@w3.org">group</a> or <a href="https://www.w3.org/about/positive-work-environment/#Procedures">individually</a>. All
         complaints will be taken seriously and will receive a response.
       </p>
       <p>
@@ -455,7 +455,7 @@
         </p>
         <p>
           You can read more in the <a href=
-          "https://www.w3.org/Consortium/pwe/#Procedures">PWETF Procedures</a>
+          "https://www.w3.org/about/positive-work-environment/#Procedures">PWETF Procedures</a>
           document.
         </p>
       </section>
@@ -498,7 +498,7 @@
         If you don't understand what you did wrong, assume that the hurt party
         has good cause and accept it. We cannot know everyone's background and
         should do our best to avoid harm. You are welcome to discuss it with a
-        W3C <a href="https://www.w3.org/Consortium/pwe/#Procedures">ombudsperson</a> later.
+        W3C <a href="https://www.w3.org/about/positive-work-environment/#ombuds">ombudsperson</a> later.
       </p>
     </section>
     <section id="glossary">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         key: "Current Operative Version",
 	      data: [
 	        { value: "",
-	          href: "http://www.w3.org/policies/code-of-conduct/" }
+	          href: "https://www.w3.org/policies/code-of-conduct/" }
         ] }
     	],
       shortName: "pwe",


### PR DESCRIPTION
We expect to host that document under /policies/. That PR updates the different links to have:
* /policies/code-of-conduct/ serving the latest published dated version
* /policies/code-of-conduct/drafts/ serving the editors draft which is a proxy to https://w3c.github.io/PWETF/

Preview is available [here](https://raw.githack.com/w3c/PWETF/new-urls/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 5:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2FPWETF%2F8b4ab883913e71b5450ee5f0d543531af4017459%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/PWETF%23367.)._
</details>
