### PR TITLE
Remove use of "CoC" acronym

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,10 +81,10 @@
           Updates to the Code of Conduct
         </h3>
         <p>
-          The Code of Conduct (CoC) is maintained by the Positive Work Environment Community Group, under delegation from the Advisory Board. In order to keep the CoC up to date with the needs and scope of W3C, PWE will routinely review and update the CoC as needed, as per the <a href="https://www.w3.org/Consortium/Process/#GAProcess">relevant section of the Process</a>. 
+          The Code of Conduct is maintained by the Positive Work Environment Community Group, under delegation from the Advisory Board. In order to keep the Code up to date with the needs and scope of W3C, PWE will routinely review and update the Code as needed, as per the <a href="https://www.w3.org/Consortium/Process/#GAProcess">relevant section of the Process</a>. 
         </p>
         <p>
-          If you have any concerns or issues with the CoC, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a>.
+          If you have any concerns or issues with the code of conduct, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a>.
         </p>
       </section>
     </section>
@@ -103,8 +103,7 @@
         resolved informally.
       </p>
         W3C's <cite>Code of Conduct</cite>
-        (<abbr title="Code of Conduct">CoC</abbr>) is
-        useful to define accepted and <a>acceptable behaviors</a> and to
+        is useful to define accepted and <a>acceptable behaviors</a> and to
         promote high standards of professional practice. The goal of this code
         of conduct is to ensure that W3C is an environment where everyone who
         participates is treated equitably and with respect, including being able to participate without fear of <a>harassment</a>. It also provides a
@@ -112,7 +111,7 @@
         of the organization.
       </p>
       <p>
-        The CoC (or "code") is complemented by a set of <a href=
+        The Code is complemented by a set of <a href=
         "https://www.w3.org/about/positive-work-environment/#Procedures">Procedures</a> and applies
         to any member of the W3C community – staff, members, invited experts,
         and <a>participants</a> in W3C meetings, W3C teleconferences, W3C
@@ -423,11 +422,11 @@
           Immediately
         </h3>
         <ul>
-          <li>Pointing out if someone is violating the CoC to give them the
+          <li>Pointing out if someone is violating the code of conduct to give them the
           chance to withdraw or edit their statement.
           </li>
           <li>Reminding <a>participants</a> that meetings and work operate
-          under the CoC.
+          under the Code.
           </li>
           <li>Asking someone to leave a meeting or a conversation thread.
           </li>
@@ -888,10 +887,10 @@
           20-Jun-2023: Revised the definition for <a>Microaggression</a> in the Glossary. See <a href="https://github.com/w3c/PWETF/pull/299">PR #299</a>.
         </li>
         <li>
-          30-May-2023: Changed the name of the CEPC to Code of Conduct (CoC). See <a href="https://github.com/w3c/PWETF/pull/297">PR #297</a>, <a href="https://github.com/w3c/PWETF/pull/288">PR #288</a>, and <a href="https://github.com/w3c/PWETF/pull/245">PR #245</a>.
+          30-May-2023: Changed the name of the CEPC to Code of Conduct. See <a href="https://github.com/w3c/PWETF/pull/297">PR #297</a>, <a href="https://github.com/w3c/PWETF/pull/288">PR #288</a>, and <a href="https://github.com/w3c/PWETF/pull/245">PR #245</a>.
         </li>
         <li>
-          16-May-2023: Edited the <a href="#abstract"></a> to better reflect the goals and content of the CoC. See <a href="https://github.com/w3c/PWETF/pull/292">PR #292</a>.
+          16-May-2023: Edited the <a href="#abstract"></a> to better reflect the goals and content of the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/292">PR #292</a>.
         </li>
         <li>
           16-May-2023: Changed the unordered lists to numbered ones. See <a href="https://github.com/w3c/PWETF/pull/291">PR #291</a> and <a href="https://github.com/w3c/PWETF/issues/259">issue #259</a>.
@@ -903,7 +902,7 @@
           16-May-2023: Added editorial recommendations from three issues (<a href="https://github.com/w3c/PWETF/issues/260">#260</a>, <a href="https://github.com/w3c/PWETF/issues/261">#261</a>, and <a href="https://github.com/w3c/PWETF/issues/262">#262</a>), regarding wording and structure for some points in the behavior sections. See <a href="https://github.com/w3c/PWETF/pull/287">PR #287</a>.
         </li>
         <li>
-          8-May-2023: Added text outlining the goal of the CoC to address <a href="https://github.com/w3c/PWETF/issues/250">issue #250</a>. See <a href="https://github.com/w3c/PWETF/pull/258">PR #258</a>.
+          8-May-2023: Added text outlining the goal of the code of conduct to address <a href="https://github.com/w3c/PWETF/issues/250">issue #250</a>. See <a href="https://github.com/w3c/PWETF/pull/258">PR #258</a>.
         </li>
         <li>
           25-Apr-2023: Revised section on patronizing language for clarity and better understanding. See <a href="https://github.com/w3c/PWETF/pull/237">PR #237</a> and <a href="https://github.com/w3c/PWETF/issues/232">issue #232</a>.
@@ -912,13 +911,13 @@
           28-Mar-2023: Minor editorial changes regarding wording in the abstract and statement of intent. See <a href="https://github.com/w3c/PWETF/pull/236">PR #236</a>.
         </li>
         <li>
-          21-Mar-2023: Added a section to the document outlining the update process PWE will follow for the CoC. See <a href="https://github.com/w3c/PWETF/pull/207">PR #207</a>.
+          21-Mar-2023: Added a section to the document outlining the update process PWE will follow for the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/207">PR #207</a>.
         </li>
         <li>
           8-Nov-2022: Update definition of <a>diversity</a> based on the language change from 27-Sep-2022. See <a href="https://github.com/w3c/PWETF/pull/214">PR #214</a>.
         </li>
         <li>
-          27-Sep-2022: Adjust the order and content of identity characteristics mentioned in the CoC. See <a href="https://github.com/w3c/PWETF/pull/209">PR #209</a>.
+          27-Sep-2022: Adjust the order and content of identity characteristics mentioned in the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/209">PR #209</a>.
         </li>
         <li>
           27-Sep-2022: Changed the language for the behavior on threats from "physical threats". See <a href="https://github.com/w3c/PWETF/pull/206">PR #206</a>.

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <p>
         W3C's <cite>Code of Conduct</cite> defines
         expected and unacceptable behaviors and promotes high standards of
-        professional practice. The goals of this code are to:
+        professional practice. The goals of this Code are to:
       </p>
       <ul>
         <li>Ensure that everyone who participates is treated equitably and with respect.
@@ -84,7 +84,7 @@
           The Code of Conduct is maintained by the Positive Work Environment Community Group, under delegation from the Advisory Board. In order to keep the Code up to date with the needs and scope of W3C, PWE will routinely review and update the Code as needed, as per the <a href="https://www.w3.org/Consortium/Process/#GAProcess">relevant section of the Process</a>. 
         </p>
         <p>
-          If you have any concerns or issues with the code of conduct, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a>.
+          If you have any concerns or issues with the Code of Conduct, they can be logged at any time in the <a href="https://github.com/w3c/PWETF/">PWE GitHub repository</a>.
         </p>
       </section>
     </section>
@@ -104,7 +104,7 @@
       </p>
         W3C's <cite>Code of Conduct</cite>
         is useful to define accepted and <a>acceptable behaviors</a> and to
-        promote high standards of professional practice. The goal of this code
+        promote high standards of professional practice. The goal of this Code
         of conduct is to ensure that W3C is an environment where everyone who
         participates is treated equitably and with respect, including being able to participate without fear of <a>harassment</a>. It also provides a
         benchmark for self evaluation and acts as a vehicle for better identity
@@ -115,8 +115,8 @@
         "https://www.w3.org/about/positive-work-environment/#Procedures">Procedures</a> and applies
         to any member of the W3C community – staff, members, invited experts,
         and <a>participants</a> in W3C meetings, W3C teleconferences, W3C
-        mailing lists, code repositories, W3C conferences or W3C functions, etc.
-        Note that this code complements rather than replaces legal rights and
+        mailing lists, Code repositories, W3C conferences or W3C functions, etc.
+        Note that this Code complements rather than replaces legal rights and
         obligations pertaining to any particular situation.
       </p>
       <p>
@@ -132,13 +132,13 @@
       <p>
         W3C is committed to maintaining a <strong>positive</strong> work environment for all, including and especially those from historically <a>marginalized communities</a>. This commitment calls for a workplace where
         <a>participants</a> at all levels behave according to the rules of the
-        following code. A foundational concept of this code is that <em>we all
+        following Code. A foundational concept of this Code is that <em>we all
         share responsibility</em> for our work environment.
       </p>
     </section>
     <section>
       <h2>
-        Code
+        Code of Conduct
       </h2>
       <section>
         <h3>
@@ -357,7 +357,7 @@
             </ul>
           </li>
           <li id=retaliation>Retaliating, or taking adverse action, against anyone who files a complaint that someone has
-          violated this code of conduct.
+          violated this Code of Conduct.
           </li>
         </ol>
 	  </section>
@@ -407,7 +407,7 @@
       <p>
         If you are responsible for a community within W3C such as in the
         role of a chair of a working group and you witness <a>harassment</a> or
-        any other behavior which goes against this code you are encouraged to
+        any other behavior which goes against this Code you are encouraged to
         address the issue directly. If you need assistance, you might get
         assistance from an Ombudsperson or senior W3C management.
       </p>
@@ -422,7 +422,7 @@
           Immediately
         </h3>
         <ul>
-          <li>Pointing out if someone is violating the code of conduct to give them the
+          <li>Pointing out if someone is violating the Code of Conduct to give them the
           chance to withdraw or edit their statement.
           </li>
           <li>Reminding <a>participants</a> that meetings and work operate
@@ -890,7 +890,7 @@
           30-May-2023: Changed the name of the CEPC to Code of Conduct. See <a href="https://github.com/w3c/PWETF/pull/297">PR #297</a>, <a href="https://github.com/w3c/PWETF/pull/288">PR #288</a>, and <a href="https://github.com/w3c/PWETF/pull/245">PR #245</a>.
         </li>
         <li>
-          16-May-2023: Edited the <a href="#abstract"></a> to better reflect the goals and content of the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/292">PR #292</a>.
+          16-May-2023: Edited the <a href="#abstract"></a> to better reflect the goals and content of the Code of Conduct. See <a href="https://github.com/w3c/PWETF/pull/292">PR #292</a>.
         </li>
         <li>
           16-May-2023: Changed the unordered lists to numbered ones. See <a href="https://github.com/w3c/PWETF/pull/291">PR #291</a> and <a href="https://github.com/w3c/PWETF/issues/259">issue #259</a>.
@@ -902,7 +902,7 @@
           16-May-2023: Added editorial recommendations from three issues (<a href="https://github.com/w3c/PWETF/issues/260">#260</a>, <a href="https://github.com/w3c/PWETF/issues/261">#261</a>, and <a href="https://github.com/w3c/PWETF/issues/262">#262</a>), regarding wording and structure for some points in the behavior sections. See <a href="https://github.com/w3c/PWETF/pull/287">PR #287</a>.
         </li>
         <li>
-          8-May-2023: Added text outlining the goal of the code of conduct to address <a href="https://github.com/w3c/PWETF/issues/250">issue #250</a>. See <a href="https://github.com/w3c/PWETF/pull/258">PR #258</a>.
+          8-May-2023: Added text outlining the goal of the Code of Conduct to address <a href="https://github.com/w3c/PWETF/issues/250">issue #250</a>. See <a href="https://github.com/w3c/PWETF/pull/258">PR #258</a>.
         </li>
         <li>
           25-Apr-2023: Revised section on patronizing language for clarity and better understanding. See <a href="https://github.com/w3c/PWETF/pull/237">PR #237</a> and <a href="https://github.com/w3c/PWETF/issues/232">issue #232</a>.
@@ -911,13 +911,13 @@
           28-Mar-2023: Minor editorial changes regarding wording in the abstract and statement of intent. See <a href="https://github.com/w3c/PWETF/pull/236">PR #236</a>.
         </li>
         <li>
-          21-Mar-2023: Added a section to the document outlining the update process PWE will follow for the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/207">PR #207</a>.
+          21-Mar-2023: Added a section to the document outlining the update process PWE will follow for the Code of Conduct. See <a href="https://github.com/w3c/PWETF/pull/207">PR #207</a>.
         </li>
         <li>
           8-Nov-2022: Update definition of <a>diversity</a> based on the language change from 27-Sep-2022. See <a href="https://github.com/w3c/PWETF/pull/214">PR #214</a>.
         </li>
         <li>
-          27-Sep-2022: Adjust the order and content of identity characteristics mentioned in the code of conduct. See <a href="https://github.com/w3c/PWETF/pull/209">PR #209</a>.
+          27-Sep-2022: Adjust the order and content of identity characteristics mentioned in the Code of Conduct. See <a href="https://github.com/w3c/PWETF/pull/209">PR #209</a>.
         </li>
         <li>
           27-Sep-2022: Changed the language for the behavior on threats from "physical threats". See <a href="https://github.com/w3c/PWETF/pull/206">PR #206</a>.
@@ -944,7 +944,7 @@
 
       <p>We'd like to acknowledge the efforts of the editors of the 2020 revision of the CEPC, Ada Rose Cannon, An Qi Li, and Tzviya Siegman, whose work got us to the revision we use today. Editing a code of conduct is a challenging task, and their insight and leadership is evident in the quality of the document we continue to work on today.</p>
 
-      <p>The following people contributed to the development of this code:</p>
+      <p>The following people contributed to the development of this Code:</p>
 
       <ul class="ack">
         <li>Ann Bassetti (W3C Invited Expert)</li>


### PR DESCRIPTION
As suggested in issue #368, removing all mentions of "CoC" and replacing them with either the full name "Code of Conduct"/"code of conduct" or "Code" where appropriate. 

Going forwards, the "short name" for the code of conduct will be the "Code".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/369.html" title="Last updated on Feb 9, 2024, 2:41 PM UTC (02c80c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/369/54b1ca2...02c80c4.html" title="Last updated on Feb 9, 2024, 2:41 PM UTC (02c80c4)">Diff</a>