### PR TITLE
Editorial: fix #409

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
           </li>
           <li id=outing>
             Deliberate disclosure of any aspect of a person’s <a>gender
-            identity</a>, <a>sexuality</a>, disability, or any other 
+            identity</a>, sexuality, disability, or any other 
             personal attributes without their <a>consent</a>.
           </li>
           <li id=publishing-private-comm>


### PR DESCRIPTION
Remove link around "sexuality" to get rid of broken definition link.  Fixes #409.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cwilso/PWETF/pull/410.html" title="Last updated on May 13, 2025, 2:12 PM UTC (616d104)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/410/be448ab...cwilso:616d104.html" title="Last updated on May 13, 2025, 2:12 PM UTC (616d104)">Diff</a>