### PR TITLE
Expand misinformation with “misinformation due to negligence”

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
           </li>
           <li id=threat>Threats.
           </li>
-          <li id=misinfo>Deliberate misinformation, or misinformation due to negligence, including responding with unchecked output from language models.
+          <li id=misinfo>Deliberate misinformation or misinformation resulting from negligence, including responding with (content based on) unchecked output from automated systems.
           </li>
           <li id=incitement>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
           </li>
           <li id=threat>Threats.
           </li>
-          <li id=misinfo>Deliberate misinformation.
+          <li id=misinfo>Deliberate misinformation, or misinformation due to negligence, including responding with unchecked output from language models.
           </li>
           <li id=incitement>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.
@@ -888,6 +888,9 @@
       <h2>Change Log</h2>
 
       <ul>
+        <li>
+          22-Sept-2025: Updated “Deliberate misinformation” to include “misinformation due to negligence”.  See <a href="https://github.com/w3c/PWETF/pull/437">PR #437</a>
+        </li>
         <li>
           6-Oct-2023: Revised the new definition for diversity based on the discussion in issue <a href="https://github.com/w3c/PWETF/issues/342">#342</a>, and added a dictionary reference for the definition of "indigeneity". See <a href="https://github.com/w3c/PWETF/pull/345">PR #345</a>.
         </li>

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
           </li>
           <li id=threat>Threats.
           </li>
-          <li id=misinfo>Deliberate misinformation or misinformation resulting from negligence, including responding with (content based on) unchecked output from automated systems.
+          <li id=misinfo>Deliberate misinformation or misinformation resulting from negligence, including responding with unchecked output from automated systems.
           </li>
           <li id=incitement>Incitement of violence towards any individual, including
           encouraging a person to commit suicide or to engage in self-harm.


### PR DESCRIPTION
This addresses part of https://github.com/w3c/PWETF/issues/432, by adding an extra example of in the list of “unacceptable behaviours”, that of misinformation due to negligence.

I did not update the French or Chinese versions, as they did not yet include the misinformation example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hidde/PWETF/pull/437.html" title="Last updated on Oct 1, 2025, 8:35 PM UTC (da4bd5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/437/c34956d...hidde:da4bd5a.html" title="Last updated on Oct 1, 2025, 8:35 PM UTC (da4bd5a)">Diff</a>