### PR TITLE
Add "dismissive" to patronizing language section

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
             Use of coded language (also known as "dog whistles") used to
             rally support for hate groups or to intimidate vulnerable groups.
           </li>
-          <li id=patronizing><a>Patronizing</a> language or behavior:
+          <li id=patronizing><a>Patronizing</a> or dismissive language or behavior:
             <ul>
               <li id=assumptions>Intentionally or unintentionally making assumptions about the skills or knowledge of others, such as using language that implies the audience is uninformed on a topic (e.g., interjections like "I can't believe you don't know about [topic]").
               </li>


### PR DESCRIPTION
To address the question raised in issue #482, adding "dismissive" to the patronizing language section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/pull/487.html" title="Last updated on Apr 28, 2026, 2:31 PM UTC (8da3f29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/PWETF/487/93d841d...8da3f29.html" title="Last updated on Apr 28, 2026, 2:31 PM UTC (8da3f29)">Diff</a>